### PR TITLE
Add company careers scraping system (#4)

### DIFF
--- a/ai-service/company_discovery.py
+++ b/ai-service/company_discovery.py
@@ -1,0 +1,250 @@
+import asyncio
+import csv
+import re
+from datetime import datetime
+
+import httpx
+
+# Starting list of Israeli tech companies to discover
+COMPANIES_TO_DISCOVER = [
+    "Wix",
+    "Monday.com",
+    "Fiverr",
+    "Taboola",
+    "Outbrain",
+    "Similarweb",
+    "Varonis",
+    "CyberArk",
+    "Amdocs",
+    "NICE Systems",
+    "Radware",
+    "Elementor",
+    "Walkme",
+    "Payoneer",
+    "eToro",
+    "Lemonade",
+    "Papaya Global",
+    "ironSource",
+    "Kaltura",
+    "Gett",
+    "Via Transportation",
+    "Lightricks",
+    "Namogoo",
+    "Cloudinary",
+    "Guesty",
+    "Minute Media",
+    "Riskified",
+    "Nuvei",
+    "Global-E",
+    "Skai",
+]
+
+# Map company names to their base URLs
+COMPANY_BASE_URLS = {
+    "Wix":            "https://www.wix.com",
+    "Monday.com":     "https://monday.com",
+    "Fiverr":         "https://www.fiverr.com",
+    "Taboola":        "https://www.taboola.com",
+    "Outbrain":       "https://www.outbrain.com",
+    "Similarweb":     "https://www.similarweb.com",
+    "Varonis":        "https://www.varonis.com",
+    "CyberArk":       "https://www.cyberark.com",
+    "Amdocs":         "https://www.amdocs.com",
+    "NICE Systems":   "https://www.nice.com",
+    "Radware":        "https://www.radware.com",
+    "Elementor":      "https://elementor.com",
+    "Walkme":         "https://www.walkme.com",
+    "Payoneer":       "https://www.payoneer.com",
+    "eToro":          "https://www.etoro.com",
+    "Lemonade":       "https://www.lemonade.com",
+    "Papaya Global":  "https://www.papayaglobal.com",
+    "ironSource":     "https://www.ironsrc.com",
+    "Kaltura":        "https://corp.kaltura.com",
+    "Gett":           "https://gett.com",
+    "Via Transportation": "https://ridewithvia.com",
+    "Lightricks":     "https://www.lightricks.com",
+    "Namogoo":        "https://www.namogoo.com",
+    "Cloudinary":     "https://cloudinary.com",
+    "Guesty":         "https://www.guesty.com",
+    "Minute Media":   "https://www.minutemedia.com",
+    "Riskified":      "https://www.riskified.com",
+    "Nuvei":          "https://www.nuvei.com",
+    "Global-E":       "https://www.global-e.com",
+    "Skai":           "https://skai.io",
+}
+
+CSV_PATH = "companies.csv"
+
+CAREERS_PATHS = [
+    "/careers",
+    "/jobs",
+    "/work-with-us",
+    "/join-us",
+    "/join-our-team",
+    "/about/careers",
+    "/company/careers",
+    "/en/careers",
+    "/about-us/careers",
+]
+
+ATS_PATTERNS = {
+    "greenhouse": r'greenhouse\.io/(?:boards/)?([a-zA-Z0-9_-]+)',
+    "lever":      r'jobs\.lever\.co/([a-zA-Z0-9_-]+)',
+    "workable":   r'apply\.workable\.com/([a-zA-Z0-9_-]+)',
+    "ashby":      r'jobs\.ashbyhq\.com/([a-zA-Z0-9_-]+)',
+    "workday":    r'myworkdayjobs\.com',
+    "smartrecruiters": r'jobs\.smartrecruiters\.com/([a-zA-Z0-9_-]+)',
+}
+
+_HTTP_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                  "AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36"
+}
+
+
+async def find_careers_url(
+    company_name: str,
+    base_url: str,
+    client: httpx.AsyncClient,
+) -> dict:
+    """
+    Try common careers URL patterns for a company.
+    Returns dict with careers_url, ats_type, slug.
+    """
+    result = {
+        "name": company_name,
+        "careers_url": "",
+        "ats_type": "unknown",
+        "slug": "",
+        "last_crawled": datetime.now().strftime("%Y-%m-%d"),
+        "active": "true",
+    }
+
+    for path in CAREERS_PATHS:
+        url = base_url.rstrip('/') + path
+        try:
+            resp = await client.get(url, timeout=10)
+
+            if resp.status_code == 200:
+                final_url = str(resp.url)
+                html = resp.text
+
+                combined = final_url + " " + html[:5000]
+
+                for ats_name, pattern in ATS_PATTERNS.items():
+                    match = re.search(pattern, combined, re.IGNORECASE)
+                    if match:
+                        result["careers_url"] = final_url
+                        result["ats_type"] = ats_name
+                        if match.lastindex and match.lastindex >= 1:
+                            result["slug"] = match.group(1)
+                        print(f"  {company_name}: found {ats_name} "
+                              f"at {final_url}")
+                        return result
+
+                result["careers_url"] = final_url
+                result["ats_type"] = "html"
+                print(f"  {company_name}: found HTML careers page "
+                      f"at {final_url}")
+                return result
+
+        except Exception:
+            continue
+
+    print(f"  {company_name}: no careers page found")
+    return result
+
+
+async def discover_all_companies() -> dict:
+    """
+    Run discovery for all companies and save to CSV.
+    Skips companies already in the CSV.
+    Returns summary with discovered count.
+    """
+    existing = {}
+    try:
+        with open(CSV_PATH, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                existing[row['name']] = row
+    except FileNotFoundError:
+        pass
+
+    new_results = []
+    to_discover = [
+        name for name in COMPANIES_TO_DISCOVER
+        if name not in existing
+    ]
+
+    if not to_discover:
+        print("All companies already discovered. Nothing to do.")
+        return {"discovered": 0, "total": 0, "csv_path": CSV_PATH}
+
+    print(f"Discovering careers URLs for {len(to_discover)} companies...")
+
+    async with httpx.AsyncClient(
+        follow_redirects=True,
+        headers=_HTTP_HEADERS,
+    ) as client:
+        for name in to_discover:
+            base_url = COMPANY_BASE_URLS.get(name, "")
+            if not base_url:
+                print(f"  {name}: no base URL configured, skipping")
+                continue
+
+            result = await find_careers_url(name, base_url, client)
+            new_results.append(result)
+            await asyncio.sleep(1.5)
+
+    all_results = list(existing.values()) + new_results
+
+    fieldnames = [
+        "name", "careers_url", "ats_type",
+        "slug", "last_crawled", "active"
+    ]
+
+    with open(CSV_PATH, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(all_results)
+
+    found = sum(1 for r in new_results if r['careers_url'])
+    print(f"\nSaved {len(all_results)} companies to {CSV_PATH}")
+    print(f"Found careers URLs: {found}/{len(new_results)}")
+
+    return {"discovered": found, "total": len(new_results), "csv_path": CSV_PATH}
+
+
+async def discover_one_company(name: str, base_url: str) -> dict:
+    """
+    Discover careers URL for a single company and upsert into CSV.
+    """
+    existing = {}
+    try:
+        with open(CSV_PATH, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                existing[row['name']] = row
+    except FileNotFoundError:
+        pass
+
+    async with httpx.AsyncClient(
+        follow_redirects=True,
+        headers=_HTTP_HEADERS,
+    ) as client:
+        result = await find_careers_url(name, base_url, client)
+
+    existing[name] = result
+    all_results = list(existing.values())
+
+    fieldnames = [
+        "name", "careers_url", "ats_type",
+        "slug", "last_crawled", "active"
+    ]
+
+    with open(CSV_PATH, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(all_results)
+
+    return result

--- a/ai-service/company_scraper.py
+++ b/ai-service/company_scraper.py
@@ -1,0 +1,208 @@
+import asyncio
+import csv
+import json
+
+import httpx
+
+CSV_PATH = "companies.csv"
+
+
+def load_companies() -> list[dict]:
+    """Load active companies from CSV"""
+    try:
+        with open(CSV_PATH, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            return [
+                row for row in reader
+                if row.get('active', 'true').lower() == 'true'
+                and row.get('careers_url', '')
+            ]
+    except FileNotFoundError:
+        print("companies.csv not found — run discovery first")
+        return []
+
+
+async def scrape_greenhouse(company: dict) -> list[dict]:
+    slug = company['slug']
+    if not slug:
+        return []
+
+    url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs"
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(url, timeout=10)
+            if resp.status_code != 200:
+                return []
+
+            jobs = []
+            for job in resp.json().get('jobs', []):
+                location = ""
+                if job.get('location'):
+                    location = job['location'].get('name', '')
+
+                jobs.append({
+                    'title': job.get('title', ''),
+                    'company': company['name'],
+                    'description': '',
+                    'location': location,
+                    'url': job.get('absolute_url', ''),
+                    'source': 'company_careers',
+                    'salary_min': None,
+                    'salary_max': None,
+                })
+            return jobs
+        except Exception as e:
+            print(f"Greenhouse error for {company['name']}: {e}")
+            return []
+
+
+async def scrape_lever(company: dict) -> list[dict]:
+    slug = company['slug']
+    if not slug:
+        return []
+
+    url = f"https://api.lever.co/v0/postings/{slug}?mode=json"
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(url, timeout=10)
+            if resp.status_code != 200:
+                return []
+
+            jobs = []
+            for posting in resp.json():
+                description = ' '.join([
+                    section.get('text', '') + ': ' +
+                    ' '.join(section.get('content', []))
+                    for section in posting.get('lists', [])
+                ])
+
+                jobs.append({
+                    'title': posting.get('text', ''),
+                    'company': company['name'],
+                    'description': description[:2000],
+                    'location': posting.get(
+                        'categories', {}
+                    ).get('location', ''),
+                    'url': posting.get('hostedUrl', ''),
+                    'source': 'company_careers',
+                    'salary_min': None,
+                    'salary_max': None,
+                })
+            return jobs
+        except Exception as e:
+            print(f"Lever error for {company['name']}: {e}")
+            return []
+
+
+async def scrape_html_page(company: dict) -> list[dict]:
+    """
+    For companies with plain HTML careers pages,
+    use Claude to extract job listings.
+    """
+    import os
+
+    from anthropic import Anthropic
+    from bs4 import BeautifulSoup
+
+    client_http = httpx.AsyncClient(follow_redirects=True)
+    anthropic_client = Anthropic(api_key=os.environ['ANTHROPIC_API_KEY'])
+
+    try:
+        resp = await client_http.get(
+            company['careers_url'], timeout=15
+        )
+        soup = BeautifulSoup(resp.text, 'html.parser')
+
+        for tag in soup(['script', 'style', 'nav',
+                         'footer', 'header']):
+            tag.decompose()
+
+        clean_text = '\n'.join(
+            line.strip()
+            for line in soup.get_text(separator='\n').split('\n')
+            if len(line.strip()) > 15
+        )[:4000]
+
+        if not clean_text:
+            return []
+
+        response = anthropic_client.messages.create(
+            model="claude-haiku-3-5",
+            max_tokens=1500,
+            messages=[{
+                "role": "user",
+                "content": f"""Extract job listings from this page.
+Return ONLY a JSON array:
+[{{"title":"...","location":"...","url":"..."}}]
+Return [] if no jobs found.
+
+Company: {company['name']}
+URL: {company['careers_url']}
+
+Content:
+{clean_text}"""
+            }]
+        )
+
+        jobs_data = json.loads(response.content[0].text)
+        return [
+            {
+                'title': j.get('title', ''),
+                'company': company['name'],
+                'description': '',
+                'location': j.get('location', ''),
+                'url': j.get('url', company['careers_url']),
+                'source': 'company_careers',
+                'salary_min': None,
+                'salary_max': None,
+            }
+            for j in jobs_data if j.get('title')
+        ]
+
+    except Exception as e:
+        print(f"HTML scrape error for {company['name']}: {e}")
+        return []
+    finally:
+        await client_http.aclose()
+
+
+async def scrape_company(company: dict) -> list[dict]:
+    """Route to correct scraper based on ATS type"""
+    ats = company.get('ats_type', 'unknown')
+
+    if ats == 'greenhouse':
+        return await scrape_greenhouse(company)
+    elif ats == 'lever':
+        return await scrape_lever(company)
+    elif ats == 'html':
+        return await scrape_html_page(company)
+    else:
+        # workday, unknown etc — skip for now
+        return []
+
+
+async def scrape_all_company_careers() -> list[dict]:
+    """
+    Main function — called by daily scheduler.
+    Reads CSV and scrapes all active companies.
+    """
+    companies = load_companies()
+    if not companies:
+        return []
+
+    print(f"Scraping {len(companies)} companies from CSV...")
+    all_jobs = []
+
+    for company in companies:
+        try:
+            jobs = await scrape_company(company)
+            if jobs:
+                print(f"  {company['name']}: {len(jobs)} jobs")
+                all_jobs.extend(jobs)
+        except Exception as e:
+            print(f"  {company['name']}: failed — {e}")
+
+        await asyncio.sleep(1)
+
+    print(f"Company scrape complete: {len(all_jobs)} total jobs")
+    return all_jobs

--- a/ai-service/routes/jobs.py
+++ b/ai-service/routes/jobs.py
@@ -1,8 +1,12 @@
+import csv
 import os
 
 import asyncpg
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
+from company_discovery import CSV_PATH, discover_all_companies, discover_one_company
 from embedder import embed
 from scraper import scrape_israel_jobs
 
@@ -63,3 +67,61 @@ async def scrape_and_store():
         await conn.close()
 
     return {"new_jobs": new_jobs, "updated_jobs": updated_jobs, "total_processed": len(jobs)}
+
+
+@router.post("/companies/discover")
+async def trigger_discovery():
+    return await discover_all_companies()
+
+
+@router.get("/companies/list")
+async def list_companies():
+    try:
+        with open(CSV_PATH, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            return list(reader)
+    except FileNotFoundError:
+        return []
+
+
+class AddCompanyRequest(BaseModel):
+    name: str
+    base_url: str
+
+
+@router.post("/companies/add")
+async def add_company(req: AddCompanyRequest):
+    return await discover_one_company(req.name, req.base_url)
+
+
+class ToggleCompanyRequest(BaseModel):
+    name: str
+    active: bool
+
+
+@router.post("/companies/toggle")
+async def toggle_company(req: ToggleCompanyRequest):
+    rows = []
+    updated = False
+    fieldnames = None
+    try:
+        with open(CSV_PATH, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames
+            for row in reader:
+                if row['name'] == req.name:
+                    row['active'] = str(req.active).lower()
+                    updated = True
+                rows.append(row)
+    except FileNotFoundError:
+        return JSONResponse(status_code=404, content={"error": "companies.csv not found"})
+
+    if not updated:
+        return JSONResponse(status_code=404, content={"error": f"Company '{req.name}' not found"})
+
+    with open(CSV_PATH, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    return {"success": True}

--- a/ai-service/scraper.py
+++ b/ai-service/scraper.py
@@ -2,6 +2,7 @@ import asyncio
 
 from jobspy import scrape_jobs
 
+from company_scraper import scrape_all_company_careers
 from scraper_alljobs import scrape_alljobs
 from scraper_drushim import scrape_drushim
 
@@ -76,6 +77,18 @@ async def scrape_israel_jobs() -> list[dict]:
             if url and url not in seen_urls and job.get("description", "").strip():
                 seen_urls.add(url)
                 results.append(job)
+
+    # Add company careers results, deduplicating by URL
+    print("Starting company careers scrape...")
+    try:
+        company_jobs = await scrape_all_company_careers()
+        for job in company_jobs:
+            url = job.get("url", "").strip()
+            if url and url not in seen_urls:
+                seen_urls.add(url)
+                results.append(job)
+    except Exception as e:
+        print(f"[scraper] company careers scrape failed: {e}")
 
     return results
 


### PR DESCRIPTION
Closes #4

## Summary
- **Phase 1** (`company_discovery.py`): crawls 30 Israeli tech companies, detects ATS type via regex (Greenhouse, Lever, Workable, Ashby, Workday, SmartRecruiters), saves to `companies.csv`
- **Phase 2** (`company_scraper.py`): reads CSV daily, scrapes via Greenhouse/Lever JSON APIs or Claude Haiku for HTML-only pages, deduplicates by URL
- **4 new endpoints** on `routes/jobs.py`: `POST /companies/discover`, `GET /companies/list`, `POST /companies/add`, `POST /companies/toggle`

## Test plan
- [ ] `POST /companies/discover` → `companies.csv` created with correct columns
- [ ] `GET /companies/list` → returns CSV rows as JSON
- [ ] `POST /companies/add {"name":"Wix","base_url":"https://www.wix.com"}` → appended to CSV
- [ ] `POST /companies/toggle {"name":"Wix","active":false}` → active field updated
- [ ] `POST /scrape-and-store` → logs show "Starting company careers scrape..."
- [ ] `ruff check ai-service/` → zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)