### PR TITLE
Add ATS platform discovery for Israeli companies (#6)

### DIFF
--- a/ai-service/ats_discovery.py
+++ b/ai-service/ats_discovery.py
@@ -1,0 +1,238 @@
+import asyncio
+import csv
+import re
+import urllib.parse
+from datetime import datetime
+
+import httpx
+from bs4 import BeautifulSoup
+
+CSV_PATH = "companies.csv"
+
+_HTTP_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+        " AppleWebKit/537.36 Chrome/120.0.0.0"
+    )
+}
+
+
+async def discover_from_greenhouse() -> list[dict]:
+    """
+    Search Greenhouse for jobs in Israel and extract unique company slugs.
+    """
+    companies_found = []
+    seen_slugs: set[str] = set()
+
+    search_terms = [
+        "Tel Aviv", "Herzliya", "Ramat Gan", "Petah Tikva",
+        "Haifa", "Beer Sheva", "Netanya", "Israel", "תל אביב",
+    ]
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        for term in search_terms:
+            try:
+                resp = await client.get(
+                    "https://api.greenhouse.io/v1/boards",
+                    params={"location": term, "per_page": 100},
+                )
+
+                if resp.status_code == 200:
+                    data = resp.json()
+                    for job in data.get("jobs", []):
+                        url = job.get("absolute_url", "")
+                        match = re.search(
+                            r'greenhouse\.io/([^/]+)/jobs', url
+                        )
+                        if match:
+                            slug = match.group(1)
+                            if slug not in seen_slugs:
+                                seen_slugs.add(slug)
+                                companies_found.append({
+                                    "slug": slug,
+                                    "company": job.get(
+                                        "company", {}
+                                    ).get("name", slug),
+                                    "location": job.get(
+                                        "location", {}
+                                    ).get("name", ""),
+                                })
+
+                await asyncio.sleep(1)
+            except Exception as e:
+                print(f"Greenhouse search error for {term}: {e}")
+
+    return companies_found
+
+
+async def discover_via_google_search(
+    client: httpx.AsyncClient,
+) -> list[dict]:
+    """
+    Search Google for Israeli companies on Greenhouse and Lever.
+    Extracts slugs from search result URLs.
+    """
+    searches = [
+        'site:boards.greenhouse.io "Tel Aviv"',
+        'site:boards.greenhouse.io "Israel"',
+        'site:boards.greenhouse.io "Herzliya"',
+        'site:boards.greenhouse.io "Ramat Gan"',
+        'site:jobs.lever.co "Tel Aviv"',
+        'site:jobs.lever.co "Israel"',
+        'site:jobs.lever.co "Herzliya"',
+    ]
+
+    greenhouse_slugs: set[str] = set()
+    lever_slugs: set[str] = set()
+
+    for query in searches:
+        try:
+            encoded = urllib.parse.quote(query)
+            url = f"https://www.google.com/search?q={encoded}&num=100"
+
+            resp = await client.get(
+                url, headers=_HTTP_HEADERS, timeout=15
+            )
+            html = resp.text
+
+            gh_matches = re.findall(
+                r'boards\.greenhouse\.io/([a-zA-Z0-9_-]+)', html
+            )
+            for slug in gh_matches:
+                if slug not in ('embed', 'api', 'v1'):
+                    greenhouse_slugs.add(slug)
+
+            lv_matches = re.findall(
+                r'jobs\.lever\.co/([a-zA-Z0-9_-]+)', html
+            )
+            lever_slugs.update(lv_matches)
+
+            await asyncio.sleep(3)
+
+        except Exception as e:
+            print(f"Google search error: {e}")
+
+    results = []
+    for slug in greenhouse_slugs:
+        results.append({
+            "slug": slug,
+            "ats_type": "greenhouse",
+            "careers_url": f"https://boards.greenhouse.io/{slug}",
+        })
+    for slug in lever_slugs:
+        results.append({
+            "slug": slug,
+            "ats_type": "lever",
+            "careers_url": f"https://jobs.lever.co/{slug}",
+        })
+
+    return results
+
+
+async def discover_from_startup_nation(
+    client: httpx.AsyncClient,
+) -> list[dict]:
+    """
+    Scrape Start-Up Nation Central for Israeli tech companies.
+    Returns list of {name, website} dicts.
+    """
+    companies = []
+
+    for page in range(1, 20):
+        url = (
+            f"https://finder.startupnationcentral.org/"
+            f"companies?page={page}&country=Israel&industry=Software"
+        )
+
+        try:
+            resp = await client.get(url, timeout=15)
+            soup = BeautifulSoup(resp.text, 'html.parser')
+
+            company_cards = soup.select(
+                '.company-card, .company-item, [class*="company"]'
+            )
+
+            for card in company_cards:
+                name_el = card.select_one('h2, h3, .company-name')
+                website_el = card.select_one('a[href*="http"]')
+
+                if name_el and website_el:
+                    companies.append({
+                        "name": name_el.get_text(strip=True),
+                        "website": website_el.get('href', ''),
+                    })
+
+            if not company_cards:
+                break
+
+            await asyncio.sleep(2)
+
+        except Exception as e:
+            print(f"StartupNation page {page} error: {e}")
+            break
+
+    return companies
+
+
+async def auto_discover_israeli_companies() -> dict:
+    """
+    Run all discovery strategies and add new companies to CSV.
+    Skips companies already in the CSV by slug.
+    """
+    existing_slugs: set[str] = set()
+    existing_names: set[str] = set()
+    existing_rows: list[dict] = []
+    fieldnames: list[str] = [
+        'name', 'careers_url', 'ats_type',
+        'slug', 'last_crawled', 'active',
+    ]
+
+    try:
+        with open(CSV_PATH, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            existing_rows = list(reader)
+            if reader.fieldnames:
+                fieldnames = list(reader.fieldnames)
+            for row in existing_rows:
+                existing_slugs.add(row.get('slug', ''))
+                existing_names.add(row.get('name', '').lower())
+    except FileNotFoundError:
+        pass
+
+    new_companies = []
+
+    async with httpx.AsyncClient(
+        follow_redirects=True,
+        headers=_HTTP_HEADERS,
+    ) as client:
+        print("Strategy 1: Searching Google for Israeli ATS boards...")
+        ats_results = await discover_via_google_search(client)
+
+        for company in ats_results:
+            slug = company.get('slug', '')
+            if slug and slug not in existing_slugs:
+                existing_slugs.add(slug)
+                new_companies.append({
+                    'name': slug,
+                    'careers_url': company['careers_url'],
+                    'ats_type': company['ats_type'],
+                    'slug': slug,
+                    'last_crawled': datetime.now().strftime('%Y-%m-%d'),
+                    'active': 'true',
+                })
+
+        print(f"  Found {len(new_companies)} new ATS companies")
+
+    if new_companies:
+        all_rows = existing_rows + new_companies
+        with open(CSV_PATH, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(all_rows)
+
+    total = len(existing_rows) + len(new_companies)
+    print(f"Added {len(new_companies)} new companies to CSV")
+    return {
+        "new_companies_found": len(new_companies),
+        "total_in_csv": total,
+    }

--- a/ai-service/routes/jobs.py
+++ b/ai-service/routes/jobs.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from ats_discovery import auto_discover_israeli_companies
 from company_discovery import CSV_PATH, discover_all_companies, discover_one_company
 from embedder import embed
 from scraper import scrape_israel_jobs
@@ -125,3 +126,8 @@ async def toggle_company(req: ToggleCompanyRequest):
         writer.writerows(rows)
 
     return {"success": True}
+
+
+@router.post("/companies/auto-discover")
+async def trigger_auto_discovery():
+    return await auto_discover_israeli_companies()


### PR DESCRIPTION
Closes #6

> **Note:** depends on #5 (company-careers) — merge that first so `companies.csv` and the company endpoints exist. This PR adds `ats_discovery.py` and the `POST /companies/auto-discover` endpoint on top.

## Summary
- `discover_via_google_search`: fires 7 Google `site:` queries for Israeli cities on `boards.greenhouse.io` and `jobs.lever.co`, extracts company slugs from HTML
- `discover_from_greenhouse`: queries Greenhouse boards API with Israeli location terms (auxiliary, may not return results from the public API)
- `discover_from_startup_nation`: scrapes StartupNation Central company directory (paginated, 20 pages × ~20 companies)
- `auto_discover_israeli_companies()`: runs the Google strategy, deduplicates by slug, appends new rows to `companies.csv`
- `POST /companies/auto-discover` → `{ new_companies_found, total_in_csv }`

## Test plan
- [ ] Merge #5 first
- [ ] `POST /companies/auto-discover` returns `{ new_companies_found, total_in_csv }`
- [ ] `GET /companies/list` shows newly discovered companies with correct `ats_type` and `slug`
- [ ] Re-running auto-discover adds 0 new companies (dedup by slug works)
- [ ] `ruff check ai-service/` → zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)