### PR TITLE
Handle flexible CSV column names in company_scraper and enrich_csv (#12)

### DIFF
--- a/ai-service/company_scraper.py
+++ b/ai-service/company_scraper.py
@@ -6,14 +6,33 @@ import httpx
 
 CSV_PATH = "companies.csv"
 
+_NAME_ALIASES = ('Company', 'company name', 'Company Name')
+_URL_ALIASES = ('Careers URL', 'Careers_URL', 'careers url', 'url', 'URL')
+
+
+def _normalize_row(row: dict) -> dict:
+    """Resolve column name aliases to the standard keys used everywhere."""
+    if not row.get('name'):
+        for alias in _NAME_ALIASES:
+            if row.get(alias):
+                row['name'] = row.pop(alias)
+                break
+    if not row.get('careers_url'):
+        for alias in _URL_ALIASES:
+            if row.get(alias):
+                row['careers_url'] = row.pop(alias)
+                break
+    return row
+
 
 def load_companies() -> list[dict]:
     """Load active companies from CSV"""
     try:
         with open(CSV_PATH, newline='', encoding='utf-8') as f:
             reader = csv.DictReader(f)
+            rows = [_normalize_row(dict(row)) for row in reader]
             return [
-                row for row in reader
+                row for row in rows
                 if row.get('active', 'true').lower() == 'true'
                 and row.get('careers_url', '')
             ]

--- a/ai-service/enrich_csv.py
+++ b/ai-service/enrich_csv.py
@@ -8,6 +8,30 @@ import httpx
 
 CSV_PATH = os.path.join(os.path.dirname(__file__), "companies.csv")
 
+_NAME_ALIASES = ('Company', 'company name', 'Company Name')
+_URL_ALIASES = ('Careers URL', 'Careers_URL', 'careers url', 'url', 'URL')
+_STANDARD_FIELDS = ['name', 'careers_url', 'ats_type', 'slug',
+                    'last_crawled', 'active']
+
+
+def _normalize_row(row: dict) -> dict:
+    """Resolve column name aliases to the standard keys used everywhere."""
+    if not row.get('name'):
+        for alias in _NAME_ALIASES:
+            if row.get(alias):
+                row['name'] = row.pop(alias)
+                break
+    if not row.get('careers_url'):
+        for alias in _URL_ALIASES:
+            if row.get(alias):
+                row['careers_url'] = row.pop(alias)
+                break
+    row.setdefault('ats_type', '')
+    row.setdefault('slug', '')
+    row.setdefault('last_crawled', '')
+    row.setdefault('active', 'true')
+    return row
+
 ATS_PATTERNS = {
     "greenhouse": [
         r'boards\.greenhouse\.io/([a-zA-Z0-9_-]+)',
@@ -80,15 +104,7 @@ async def enrich_companies_csv():
         return
 
     # Normalise column names and fill missing fields
-    for row in rows:
-        if 'url' in row and 'careers_url' not in row:
-            row['careers_url'] = row.pop('url')
-        if 'URL' in row and 'careers_url' not in row:
-            row['careers_url'] = row.pop('URL')
-        row.setdefault('ats_type', '')
-        row.setdefault('slug', '')
-        row.setdefault('last_crawled', '')
-        row.setdefault('active', 'true')
+    rows = [_normalize_row(row) for row in rows]
 
     to_enrich = [
         row for row in rows
@@ -136,10 +152,8 @@ async def enrich_companies_csv():
     print(f"  Lever:      {lever}")
     print(f"  HTML:       {html}")
 
-    required_fields = ['name', 'careers_url', 'ats_type', 'slug',
-                       'last_crawled', 'active']
     with open(CSV_PATH, 'w', newline='', encoding='utf-8') as f:
-        writer = csv.DictWriter(f, fieldnames=required_fields,
+        writer = csv.DictWriter(f, fieldnames=_STANDARD_FIELDS,
                                 extrasaction='ignore')
         writer.writeheader()
         writer.writerows(rows)


### PR DESCRIPTION
Closes #12

## Summary
- Adds `_normalize_row()` helper in both files that resolves column aliases on read:
  - `name` ← `Company` | `company name` | `Company Name`
  - `careers_url` ← `Careers URL` | `Careers_URL` | `careers url` | `url` | `URL`
- `enrich_csv.py` always writes with standard headers (`name, careers_url, ats_type, slug, last_crawled, active`) regardless of input format

## Test plan
- [ ] Place `companies.csv` with `Company` / `Careers URL` headers into `ai-service/`
- [ ] `POST /companies/enrich` → runs without "no careers_url" skips, detects ATS correctly
- [ ] Output CSV has standard headers
- [ ] `GET /companies/list` returns rows with `name` and `careers_url` populated
- [ ] `ruff check ai-service/` → zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)