### PR TITLE
Add Browse All Jobs tab with search, filters and pagination

### DIFF
--- a/app/api/jobs/browse/route.ts
+++ b/app/api/jobs/browse/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+
+const LIMIT_DEFAULT = 20;
+const LIMIT_MAX = 50;
+
+export async function GET(req: NextRequest) {
+  const sp = req.nextUrl.searchParams;
+  const search = sp.get("search")?.trim() ?? "";
+  const location = sp.get("location")?.trim() ?? "";
+  const company = sp.get("company")?.trim() ?? "";
+  const source = sp.get("source")?.trim() ?? "";
+  const page = Math.max(1, Number(sp.get("page") ?? 1));
+  const limit = Math.min(LIMIT_MAX, Math.max(1, Number(sp.get("limit") ?? LIMIT_DEFAULT)));
+
+  const where = {
+    AND: [
+      ...(search
+        ? [
+            {
+              OR: [
+                { title: { contains: search, mode: "insensitive" as const } },
+                { company: { contains: search, mode: "insensitive" as const } },
+                { description: { contains: search, mode: "insensitive" as const } },
+              ],
+            },
+          ]
+        : []),
+      ...(location ? [{ location: { contains: location, mode: "insensitive" as const } }] : []),
+      ...(company ? [{ company: { contains: company, mode: "insensitive" as const } }] : []),
+      ...(source ? [{ source }] : []),
+    ],
+  };
+
+  try {
+    const [jobs, total] = await Promise.all([
+      db.job.findMany({
+        where,
+        select: {
+          id: true,
+          title: true,
+          company: true,
+          location: true,
+          url: true,
+          source: true,
+          salary_min: true,
+          salary_max: true,
+          scraped_at: true,
+          description: true,
+        },
+        orderBy: { scraped_at: "desc" },
+        take: limit,
+        skip: (page - 1) * limit,
+      }),
+      db.job.count({ where }),
+    ]);
+
+    return NextResponse.json({
+      jobs: jobs.map((j) => ({ ...j, description: j.description?.slice(0, 300) ?? "" })),
+      total,
+      page,
+      total_pages: Math.ceil(total / limit),
+      limit,
+    });
+  } catch (err) {
+    console.error("[browse]", err);
+    return NextResponse.json({ error: "Failed to fetch jobs" }, { status: 500 });
+  }
+}

--- a/app/dashboard/JobCard.tsx
+++ b/app/dashboard/JobCard.tsx
@@ -9,28 +9,73 @@ export interface Job {
   title: string;
   company: string;
   description: string;
-  location: string;
+  location: string | null;
   url: string;
+  source?: string;
   salary_min: number | null;
   salary_max: number | null;
   scraped_at: string;
-  similarity: number;
-  claude_score: number;
-  reasons: string[];
-  gaps: string[];
+  similarity?: number;
+  claude_score?: number;
+  reasons?: string[];
+  gaps?: string[];
 }
 
-export default function JobCard({ job, initialSaved = false, onDismiss }: { job: Job; initialSaved?: boolean; onDismiss?: (id: string) => void }) {
+interface Props {
+  job: Job;
+  initialSaved?: boolean;
+  onDismiss?: (id: string) => void;
+  showScore?: boolean;
+  showSource?: boolean;
+}
+
+function daysAgo(dateStr: string): string {
+  const mins = Math.floor((Date.now() - new Date(dateStr).getTime()) / 60_000);
+  if (mins < 60) return "just now";
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function SourcePill({ source }: { source: string }) {
+  const s = source.toLowerCase();
+  if (s === "indeed")
+    return (
+      <span className="text-xs px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+        Indeed
+      </span>
+    );
+  if (s === "linkedin")
+    return (
+      <span className="text-xs px-1.5 py-0.5 rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+        LinkedIn
+      </span>
+    );
+  return (
+    <span className="text-xs px-1.5 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300">
+      Company
+    </span>
+  );
+}
+
+export default function JobCard({
+  job,
+  initialSaved = false,
+  onDismiss,
+  showScore = true,
+  showSource = false,
+}: Props) {
   const [expanded, setExpanded] = useState(false);
   const [saved, setSaved] = useState(initialSaved);
   const [saving, setSaving] = useState(false);
   const [dismissing, setDismissing] = useState(false);
   const router = useRouter();
 
-  // Fall back to vector similarity when Claude scoring didn't run
-  const score = job.claude_score > 0
-    ? job.claude_score
-    : Math.round(job.similarity * 100);
+  const score =
+    (job.claude_score ?? 0) > 0
+      ? job.claude_score!
+      : Math.round((job.similarity ?? 0) * 100);
   const scoreColor =
     score >= 80
       ? "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-400"
@@ -53,12 +98,14 @@ export default function JobCard({ job, initialSaved = false, onDismiss }: { job:
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ job_id: job.id, action: "dismissed" }),
       });
-      // Let the fade complete before removing from list
       setTimeout(() => onDismiss?.(job.id), 300);
     } catch {
       setDismissing(false);
     }
   }
+
+  const reasons = job.reasons ?? [];
+  const gaps = job.gaps ?? [];
 
   return (
     <div
@@ -74,15 +121,24 @@ export default function JobCard({ job, initialSaved = false, onDismiss }: { job:
             {job.company}
             {job.location ? ` · ${job.location}` : ""}
           </p>
+          {showSource && job.source && (
+            <div className="mt-1">
+              <SourcePill source={job.source} />
+            </div>
+          )}
           {salary && (
             <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{salary}</p>
           )}
         </div>
-        <span
-          className={`shrink-0 text-sm font-semibold px-2.5 py-1 rounded-full ${scoreColor}`}
-        >
-          {score}%
-        </span>
+        {showScore ? (
+          <span className={`shrink-0 text-sm font-semibold px-2.5 py-1 rounded-full ${scoreColor}`}>
+            {score}%
+          </span>
+        ) : (
+          <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+            {daysAgo(job.scraped_at)}
+          </span>
+        )}
       </div>
 
       {/* Description preview */}
@@ -102,13 +158,13 @@ export default function JobCard({ job, initialSaved = false, onDismiss }: { job:
 
       {expanded && (
         <div className="mt-3 space-y-3">
-          {job.reasons.length > 0 && (
+          {reasons.length > 0 && (
             <div>
               <p className="text-xs font-semibold text-green-700 dark:text-green-400 mb-1">
                 Why it fits
               </p>
               <ul className="space-y-0.5">
-                {job.reasons.map((r, i) => (
+                {reasons.map((r, i) => (
                   <li key={i} className="text-xs text-gray-700 dark:text-gray-300 flex gap-1.5">
                     <span className="text-green-500 shrink-0">✓</span>
                     {r}
@@ -117,11 +173,11 @@ export default function JobCard({ job, initialSaved = false, onDismiss }: { job:
               </ul>
             </div>
           )}
-          {job.gaps.length > 0 && (
+          {gaps.length > 0 && (
             <div>
               <p className="text-xs font-semibold text-amber-700 dark:text-amber-400 mb-1">Gaps</p>
               <ul className="space-y-0.5">
-                {job.gaps.map((g, i) => (
+                {gaps.map((g, i) => (
                   <li key={i} className="text-xs text-gray-700 dark:text-gray-300 flex gap-1.5">
                     <span className="text-amber-400 shrink-0">!</span>
                     {g}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import JobCard, { Job } from "./JobCard";
 import JobFilters, { DEFAULT_FILTERS, Filters } from "@/app/components/JobFilters";
@@ -16,7 +16,7 @@ function timeAgo(date: Date): string {
 }
 
 function jobScore(job: Job): number {
-  return job.claude_score > 0 ? job.claude_score : Math.round(job.similarity * 100);
+  return (job.claude_score ?? 0) > 0 ? job.claude_score! : Math.round((job.similarity ?? 0) * 100);
 }
 
 function workTypeMatch(job: Job, workTypes: Filters["workTypes"]): boolean {
@@ -58,7 +58,6 @@ function salaryMatch(job: Job, minSalary: string): boolean {
   if (!minSalary) return true;
   const min = parseInt(minSalary);
   if (isNaN(min)) return true;
-  // Jobs with no salary data are always shown
   if (job.salary_max == null && job.salary_min == null) return true;
   const best = job.salary_max ?? job.salary_min ?? 0;
   return best >= min;
@@ -80,7 +79,34 @@ function applySort(jobs: Job[], sortBy: Filters["sortBy"]): Job[] {
   return arr;
 }
 
+interface BrowseJob {
+  id: string;
+  title: string;
+  company: string;
+  description: string;
+  location: string | null;
+  url: string;
+  source: string;
+  salary_min: number | null;
+  salary_max: number | null;
+  scraped_at: string;
+}
+
+function SkeletonCard() {
+  return (
+    <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5 animate-pulse">
+      <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2 mb-2" />
+      <div className="h-3 bg-gray-100 dark:bg-gray-600 rounded w-1/3 mb-4" />
+      <div className="h-3 bg-gray-100 dark:bg-gray-600 rounded w-full mb-1" />
+      <div className="h-3 bg-gray-100 dark:bg-gray-600 rounded w-4/5" />
+    </div>
+  );
+}
+
 export default function DashboardPage() {
+  const [activeTab, setActiveTab] = useState<"matches" | "browse">("matches");
+
+  // --- My Matches state ---
   const [jobs, setJobs] = useState<Job[]>([]);
   const [savedIds, setSavedIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
@@ -89,6 +115,71 @@ export default function DashboardPage() {
   const [, setTick] = useState(0);
   const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
   const router = useRouter();
+
+  // --- Browse state ---
+  const [browseSearch, setBrowseSearch] = useState("");
+  const [browseLocation, setBrowseLocation] = useState("");
+  const [browseCompany, setBrowseCompany] = useState("");
+  const [browseSource, setBrowseSource] = useState("");
+  const [browsePage, setBrowsePage] = useState(1);
+  const [browseJobs, setBrowseJobs] = useState<BrowseJob[]>([]);
+  const [browseTotal, setBrowseTotal] = useState(0);
+  const [browseTotalPages, setBrowseTotalPages] = useState(0);
+  const [browseLoading, setBrowseLoading] = useState(false);
+  const [browseGoTo, setBrowseGoTo] = useState("");
+  const browseListRef = useRef<HTMLDivElement>(null);
+  const browseDebounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Always-fresh filter values — avoids stale closures inside debounce timers
+  const browseFiltersRef = useRef({ search: "", location: "", company: "", source: "" });
+  browseFiltersRef.current = { search: browseSearch, location: browseLocation, company: browseCompany, source: browseSource };
+
+  const fetchBrowse = useCallback(async (page: number) => {
+    setBrowseLoading(true);
+    try {
+      const { search, location, company, source } = browseFiltersRef.current;
+      const params = new URLSearchParams({ page: String(page) });
+      if (search) params.set("search", search);
+      if (location) params.set("location", location);
+      if (company) params.set("company", company);
+      if (source) params.set("source", source);
+      const res = await fetch(`/api/jobs/browse?${params}`);
+      if (!res.ok) throw new Error("Failed to load");
+      const data = await res.json();
+      setBrowseJobs(data.jobs);
+      setBrowseTotal(data.total);
+      setBrowseTotalPages(data.total_pages);
+      setBrowsePage(data.page);
+    } catch (err) {
+      console.error("browse:", err);
+    } finally {
+      setBrowseLoading(false);
+    }
+  }, []); // stable — reads live values via ref
+
+  function debounceBrowse(delay = 400) {
+    clearTimeout(browseDebounceRef.current);
+    browseDebounceRef.current = setTimeout(() => fetchBrowse(1), delay);
+  }
+
+  function clearBrowseFilters() {
+    setBrowseSearch("");
+    setBrowseLocation("");
+    setBrowseCompany("");
+    setBrowseSource("");
+    // Fire after re-render so ref reflects cleared values
+    setTimeout(() => fetchBrowse(1), 0);
+  }
+
+  function goToPage(p: number) {
+    if (p < 1 || p > browseTotalPages) return;
+    fetchBrowse(p);
+    setTimeout(() => browseListRef.current?.scrollIntoView({ behavior: "smooth" }), 50);
+  }
+
+  useEffect(() => {
+    if (activeTab === "browse") fetchBrowse(1);
+  }, [activeTab, fetchBrowse]);
 
   // Re-render every minute so "X minutes ago" stays live
   useEffect(() => {
@@ -119,7 +210,6 @@ export default function DashboardPage() {
     }
   }, []);
 
-  // Guard: redirect to onboarding if no CV uploaded yet
   useEffect(() => {
     fetch("/api/profile")
       .then((r) => r.json())
@@ -139,92 +229,287 @@ export default function DashboardPage() {
     return applySort(filtered, filters.sortBy);
   }, [jobs, filters]);
 
+  const hasBrowseFilter = browseSearch || browseLocation || browseCompany || browseSource;
+  const browseFrom = browseTotal === 0 ? 0 : (browsePage - 1) * 20 + 1;
+  const browseTo = browseFrom > 0 ? browseFrom + browseJobs.length - 1 : 0;
+
   return (
     <div className="max-w-3xl mx-auto">
-      <div className="flex items-center justify-between mb-4">
-        <div>
-          <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Matched Jobs</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Top matches based on your CV</p>
-        </div>
-        <div className="flex items-center gap-3">
-          {lastFetched && !loading && (
-            <span className="text-xs text-gray-400 dark:text-gray-500">
-              Last updated: {timeAgo(lastFetched)}
-            </span>
-          )}
+      {/* Tab bar */}
+      <div className="flex gap-1 mb-6 border-b dark:border-gray-700">
+        {(["matches", "browse"] as const).map((tab) => (
           <button
-            onClick={() => fetchJobs(true)}
-            disabled={loading}
-            className="text-sm font-medium px-3 py-1.5 border rounded-lg hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 disabled:opacity-40 transition-colors"
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px ${
+              activeTab === tab
+                ? "border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400"
+                : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            }`}
           >
-            {loading ? "Loading…" : "Refresh"}
+            {tab === "matches" ? "My Matches" : "Browse All Jobs"}
           </button>
-        </div>
+        ))}
       </div>
 
-      <JobFilters
-        filters={filters}
-        onChange={setFilters}
-        matchCount={!loading && !error && jobs.length > 0 ? filteredJobs.length : undefined}
-        totalCount={!loading && !error && jobs.length > 0 ? jobs.length : undefined}
-      />
+      {/* ── My Matches ── */}
+      {activeTab === "matches" && (
+        <>
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Matched Jobs</h1>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Top matches based on your CV</p>
+            </div>
+            <div className="flex items-center gap-3">
+              {lastFetched && !loading && (
+                <span className="text-xs text-gray-400 dark:text-gray-500">
+                  Last updated: {timeAgo(lastFetched)}
+                </span>
+              )}
+              <button
+                onClick={() => fetchJobs(true)}
+                disabled={loading}
+                className="text-sm font-medium px-3 py-1.5 border rounded-lg hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 disabled:opacity-40 transition-colors"
+              >
+                {loading ? "Loading…" : "Refresh"}
+              </button>
+            </div>
+          </div>
 
-      <div className="mt-4">
+          <JobFilters
+            filters={filters}
+            onChange={setFilters}
+            matchCount={!loading && !error && jobs.length > 0 ? filteredJobs.length : undefined}
+            totalCount={!loading && !error && jobs.length > 0 ? jobs.length : undefined}
+          />
 
-        {loading && (
-          <div className="space-y-4">
-            {[...Array(3)].map((_, i) => (
-              <div key={i} className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5 animate-pulse">
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2 mb-2" />
-                <div className="h-3 bg-gray-100 dark:bg-gray-600 rounded w-1/3 mb-4" />
-                <div className="h-3 bg-gray-100 dark:bg-gray-600 rounded w-full mb-1" />
-                <div className="h-3 bg-gray-100 dark:bg-gray-600 rounded w-4/5" />
+          <div className="mt-4">
+            {loading && (
+              <div className="space-y-4">
+                {[...Array(3)].map((_, i) => (
+                  <div key={i} className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5 animate-pulse">
+                    <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2 mb-2" />
+                    <div className="h-3 bg-gray-100 dark:bg-gray-600 rounded w-1/3 mb-4" />
+                    <div className="h-3 bg-gray-100 dark:bg-gray-600 rounded w-full mb-1" />
+                    <div className="h-3 bg-gray-100 dark:bg-gray-600 rounded w-4/5" />
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        )}
+            )}
 
-        {error && (
-          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-5 text-sm text-red-700 dark:text-red-400">
-            {error}
-          </div>
-        )}
+            {error && (
+              <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-5 text-sm text-red-700 dark:text-red-400">
+                {error}
+              </div>
+            )}
 
-        {!loading && !error && jobs.length === 0 && (
-          <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-10 text-center">
-            <p className="text-gray-700 dark:text-gray-300 font-medium">No new matches today.</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-              Check back tomorrow or{" "}
-              <a href="/dashboard/onboarding" className="text-blue-600 dark:text-blue-400 hover:underline">
-                update your preferences
-              </a>
-              .
+            {!loading && !error && jobs.length === 0 && (
+              <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-10 text-center">
+                <p className="text-gray-700 dark:text-gray-300 font-medium">No new matches today.</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  Check back tomorrow or{" "}
+                  <a href="/dashboard/onboarding" className="text-blue-600 dark:text-blue-400 hover:underline">
+                    update your preferences
+                  </a>
+                  .
+                </p>
+              </div>
+            )}
+
+            {!loading && !error && jobs.length > 0 && filteredJobs.length === 0 && (
+              <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-10 text-center">
+                <p className="text-gray-700 dark:text-gray-300 font-medium">No jobs match your filters.</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  Try adjusting the filters above.
+                </p>
+              </div>
+            )}
+
+            {!loading && !error && filteredJobs.length > 0 && (
+              <div className="space-y-4">
+                {filteredJobs.map((job) => (
+                  <JobCard
+                    key={job.id}
+                    job={job}
+                    initialSaved={savedIds.has(job.id)}
+                    onDismiss={(id) => setJobs((prev) => prev.filter((j) => j.id !== id))}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* ── Browse All Jobs ── */}
+      {activeTab === "browse" && (
+        <div>
+          {/* Search bar */}
+          <div className="relative mb-3">
+            <input
+              type="text"
+              value={browseSearch}
+              onChange={(e) => {
+                setBrowseSearch(e.target.value);
+                debounceBrowse(400);
+              }}
+              placeholder="Search by title, company, or keyword..."
+              className="w-full px-4 py-2.5 pr-10 border rounded-xl text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {browseLoading && (
+              <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                <svg className="animate-spin h-4 w-4 text-gray-400" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                </svg>
+              </div>
+            )}
+          </div>
+
+          {/* Filter row */}
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            <input
+              type="text"
+              value={browseLocation}
+              onChange={(e) => {
+                setBrowseLocation(e.target.value);
+                debounceBrowse(400);
+              }}
+              placeholder="Location"
+              className="w-36 px-3 py-1.5 border rounded-lg text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <input
+              type="text"
+              value={browseCompany}
+              onChange={(e) => {
+                setBrowseCompany(e.target.value);
+                debounceBrowse(400);
+              }}
+              placeholder="Company"
+              className="w-36 px-3 py-1.5 border rounded-lg text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <select
+              value={browseSource}
+              onChange={(e) => {
+                setBrowseSource(e.target.value);
+                setTimeout(() => fetchBrowse(1), 0);
+              }}
+              className="px-3 py-1.5 border rounded-lg text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">All sources</option>
+              <option value="Indeed">Indeed</option>
+              <option value="LinkedIn">LinkedIn</option>
+              <option value="company_careers">Company Careers</option>
+            </select>
+            {hasBrowseFilter && (
+              <button
+                onClick={clearBrowseFilters}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+
+          {/* Results count */}
+          {!browseLoading && browseTotal > 0 && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+              Showing {browseFrom}–{browseTo} of {browseTotal.toLocaleString()} jobs
             </p>
-          </div>
-        )}
+          )}
 
-        {!loading && !error && jobs.length > 0 && filteredJobs.length === 0 && (
-          <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-10 text-center">
-            <p className="text-gray-700 dark:text-gray-300 font-medium">No jobs match your filters.</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-              Try adjusting the filters above.
-            </p>
+          {/* Job list */}
+          <div ref={browseListRef}>
+            {browseLoading ? (
+              <div className="space-y-4">
+                <SkeletonCard />
+                <SkeletonCard />
+                <SkeletonCard />
+              </div>
+            ) : browseJobs.length === 0 ? (
+              <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-10 text-center">
+                <p className="text-gray-700 dark:text-gray-300 font-medium">
+                  No jobs found matching your filters.
+                </p>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  Try different keywords
+                  {hasBrowseFilter && (
+                    <>
+                      {" or "}
+                      <button
+                        onClick={clearBrowseFilters}
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        clear the filters
+                      </button>
+                    </>
+                  )}
+                  .
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {browseJobs.map((job) => (
+                  <JobCard
+                    key={job.id}
+                    job={job}
+                    showScore={false}
+                    showSource={true}
+                    onDismiss={(id) => setBrowseJobs((prev) => prev.filter((j) => j.id !== id))}
+                  />
+                ))}
+              </div>
+            )}
           </div>
-        )}
 
-        {!loading && !error && filteredJobs.length > 0 && (
-          <div className="space-y-4">
-            {filteredJobs.map((job) => (
-              <JobCard
-                key={job.id}
-                job={job}
-                initialSaved={savedIds.has(job.id)}
-                onDismiss={(id) => setJobs((prev) => prev.filter((j) => j.id !== id))}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+          {/* Pagination */}
+          {!browseLoading && browseTotalPages > 1 && (
+            <div className="mt-6 flex flex-col items-center gap-3">
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => goToPage(browsePage - 1)}
+                  disabled={browsePage <= 1}
+                  className="text-sm px-3 py-1.5 border rounded-lg hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 disabled:opacity-40 transition-colors"
+                >
+                  ← Previous
+                </button>
+                <span className="text-sm text-gray-600 dark:text-gray-400">
+                  Page {browsePage} of {browseTotalPages}
+                </span>
+                <button
+                  onClick={() => goToPage(browsePage + 1)}
+                  disabled={browsePage >= browseTotalPages}
+                  className="text-sm px-3 py-1.5 border rounded-lg hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 disabled:opacity-40 transition-colors"
+                >
+                  Next →
+                </button>
+              </div>
+              <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+                <span>Go to page</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={browseTotalPages}
+                  value={browseGoTo}
+                  onChange={(e) => setBrowseGoTo(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const p = parseInt(browseGoTo, 10);
+                      if (!isNaN(p)) {
+                        goToPage(p);
+                        setBrowseGoTo("");
+                      }
+                    }
+                  }}
+                  placeholder={String(browsePage)}
+                  className="w-16 px-2 py-1 border rounded-lg text-center text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <span>of {browseTotalPages}</span>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #24

## What this adds

- New **Browse All Jobs** tab on the dashboard (sits next to My Matches)
- Shows all jobs in DB without CV matching — pure DB query, no AI
- Search by keyword (title / company / description), filter by location, company, source
- 20 jobs per page with Previous / Next controls and a go-to-page input
- Spinner inside search bar while loading; skeleton cards for the list area
- Source pill on each card (Indeed = blue, LinkedIn = indigo, Company Careers = green)
- Shows "Xd ago" timestamp instead of a match-score badge

## Changes

| File | What changed |
|------|-------------|
| `app/api/jobs/browse/route.ts` | New GET endpoint — Prisma query with search/location/company/source/page |
| `app/dashboard/page.tsx` | Tab bar, full Browse tab UI, debounced fetch, pagination |
| `app/dashboard/JobCard.tsx` | `showScore` + `showSource` optional props; AI fields made optional in `Job` type |

## How to test

- Go to dashboard → click **Browse All Jobs** tab
- Type in the search bar — results update after 400ms
- Change location / company / source — page resets to 1
- Click Next / Previous to paginate; list scrolls to top
- Click Apply on a browse result — tailoring flow works normally
- Switch back to **My Matches** — existing behaviour unchanged

## Performance note

Run these indexes in the Supabase SQL editor before going to production:

```sql
CREATE INDEX IF NOT EXISTS idx_jobs_scraped_at ON jobs (scraped_at DESC);
CREATE INDEX IF NOT EXISTS idx_jobs_title_gin ON jobs USING gin(to_tsvector('english', title));
CREATE INDEX IF NOT EXISTS idx_jobs_company ON jobs (company);
```

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)