### PR TITLE
fix: keep CV preview on white background in dark mode

### DIFF
--- a/app/dashboard/my-cv/page.tsx
+++ b/app/dashboard/my-cv/page.tsx
@@ -17,7 +17,7 @@ function CVPreview({ cvText }: { cvText: string }) {
   return (
     <>
       <style>{`@import url('https://fonts.googleapis.com/css2?family=Carlito:ital,wght@0,400;0,700;1,400;1,700&display=swap');`}</style>
-      <div className="px-8 py-7 text-[13px] leading-relaxed text-gray-800" style={{ fontFamily: "Calibri, Carlito, Arial, sans-serif" }}>
+      <div className="bg-white px-8 py-7 text-[13px] leading-relaxed text-gray-800" style={{ fontFamily: "Calibri, Carlito, Arial, sans-serif" }}>
         {lines.map((line, i) => {
           const trimmed = line.trim();
           if (!nameWritten && trimmed) {
@@ -125,7 +125,7 @@ export default function MyCVPage() {
           <div className="bg-gray-50 dark:bg-gray-900/50 border-b dark:border-gray-700 px-5 py-2">
             <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">preview</span>
           </div>
-          <div className="max-h-[70vh] overflow-y-auto">
+          <div className="max-h-[70vh] overflow-y-auto bg-white">
             <CVPreview cvText={cvText} />
           </div>
         </div>


### PR DESCRIPTION
Closes #28

## Problem

In dark mode, the CV preview on `/dashboard/my-cv` becomes nearly unreadable. The `CVPreview` component uses hardcoded dark Tailwind text classes (`text-gray-800`, `text-gray-900`, `text-gray-700`) with no `dark:` variants. The card container correctly applies `dark:bg-gray-800`, but the preview content area inherits that dark background — making the CV text invisible against it.

## Root cause

`CVPreview`'s root `<div>` had no background colour, so it inherited `dark:bg-gray-800` from the parent card, while all text remained dark-coloured.

## Fix

Added `bg-white` to both the `<CVPreview>` root div and its parent scroll container (`max-h-[70vh]`). A CV preview simulates a printed paper document and should always appear on white, regardless of the app's colour scheme — the card chrome (border, shadow) remains dark-mode-aware.

## Screenshot evidence (Playwright)

| Before | After |
|--------|-------|
| Dark bg + dark text = invisible | White bg = fully readable |

_(See `screenshots/cv-dark-mode-comparison.png` — top panel is before, bottom is after)_

## Test plan

- [ ] Toggle dark mode on `/dashboard/my-cv` — CV text must be clearly readable
- [ ] Light mode still renders correctly (white bg on white page, no visual change)
- [ ] Scroll area background stays white even when content is shorter than 70vh

🤖 Generated with [Claude Code](https://claude.com/claude-code)