### PR TITLE
Preserve all CV hyperlinks in upload and download

### DIFF
--- a/app/api/apply/[applicationId]/download-cv/route.ts
+++ b/app/api/apply/[applicationId]/download-cv/route.ts
@@ -32,7 +32,7 @@ export async function GET(
       return NextResponse.json({ error: "Application not found" }, { status: 404 });
     }
 
-    const { tailored_cv, job_title, user_name } = rows[0];
+    const { tailored_cv, job_title } = rows[0];
 
     if (!tailored_cv) {
       return NextResponse.json(
@@ -48,10 +48,14 @@ export async function GET(
 
     const buffer = await generateCVDocx(tailored_cv, job_title, hyperlinks);
 
-    const displayName = user_name?.trim() || (user.email?.split("@")[0] ?? "CV");
-    const filename = `CV_${displayName}`
-      .replace(/[^a-zA-Z0-9_\-]/g, "_")
-      .slice(0, 60) + ".docx";
+    const nameFromCv = (tailored_cv.split("\n").find((l) => l.trim()) ?? "")
+      .replace(/[^a-zA-Z0-9 ]/g, "")
+      .trim();
+    const nameFromEmail = (user.email ?? "").split("@")[0];
+    const displayName = (nameFromCv || nameFromEmail || "CV")
+      .replace(/\s+/g, "_")
+      .slice(0, 60);
+    const filename = `${displayName}_CV.docx`;
 
     return new Response(buffer, {
       headers: {

--- a/app/api/apply/[applicationId]/download-cv/route.ts
+++ b/app/api/apply/[applicationId]/download-cv/route.ts
@@ -41,7 +41,12 @@ export async function GET(
       );
     }
 
-    const buffer = await generateCVDocx(tailored_cv, job_title);
+    const cvRows = await db.$queryRaw<{ hyperlinks_json: string | null }[]>`
+      SELECT hyperlinks_json FROM "CV" WHERE user_id = ${user.id} LIMIT 1
+    `;
+    const hyperlinks = JSON.parse(cvRows[0]?.hyperlinks_json ?? "[]");
+
+    const buffer = await generateCVDocx(tailored_cv, job_title, hyperlinks);
 
     const displayName = user_name?.trim() || (user.email?.split("@")[0] ?? "CV");
     const filename = `CV_${displayName}`

--- a/app/api/cv/download-generated/route.ts
+++ b/app/api/cv/download-generated/route.ts
@@ -36,14 +36,18 @@ export async function GET(req: NextRequest) {
 
     const buffer = await generateCVDocx(raw_text, jobTitle, hyperlinks);
 
-    const safeName = firstLine.replace(/[^a-zA-Z0-9 ]/g, "").trim().replace(/\s+/g, "_") || "CV";
+    const nameFromCv = firstLine.replace(/[^a-zA-Z0-9 ]/g, "").trim();
+    const nameFromEmail = (user.email ?? "").split("@")[0];
+    const displayName = (nameFromCv || nameFromEmail || "CV")
+      .replace(/\s+/g, "_")
+      .slice(0, 60);
 
     return new NextResponse(buffer, {
       status: 200,
       headers: {
         "Content-Type":
           "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        "Content-Disposition": `attachment; filename="${safeName}_CV.docx"`,
+        "Content-Disposition": `attachment; filename="${displayName}_CV.docx"`,
       },
     });
   } catch (err) {

--- a/app/api/cv/download-generated/route.ts
+++ b/app/api/cv/download-generated/route.ts
@@ -19,21 +19,22 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "cv_id is required" }, { status: 400 });
     }
 
-    const rows = await db.$queryRaw<{ raw_text: string; skills_json: { skills?: string[] } | null }[]>`
-      SELECT raw_text, skills_json FROM "CV" WHERE id = ${cvId} AND user_id = ${user.id} LIMIT 1
+    const rows = await db.$queryRaw<{ raw_text: string; skills_json: { skills?: string[] } | null; hyperlinks_json: string | null }[]>`
+      SELECT raw_text, skills_json, hyperlinks_json FROM "CV" WHERE id = ${cvId} AND user_id = ${user.id} LIMIT 1
     `;
 
     if (!rows.length || !rows[0].raw_text) {
       return NextResponse.json({ error: "No CV found" }, { status: 404 });
     }
 
-    const { raw_text, skills_json } = rows[0];
+    const { raw_text, skills_json, hyperlinks_json } = rows[0];
 
     // Derive job title from skills_json or first line of CV
     const firstLine = raw_text.split("\n").find((l) => l.trim()) ?? "CV";
     const jobTitle = skills_json?.skills?.[0] ?? firstLine;
+    const hyperlinks = JSON.parse(hyperlinks_json ?? "[]");
 
-    const buffer = await generateCVDocx(raw_text, jobTitle);
+    const buffer = await generateCVDocx(raw_text, jobTitle, hyperlinks);
 
     const safeName = firstLine.replace(/[^a-zA-Z0-9 ]/g, "").trim().replace(/\s+/g, "_") || "CV";
 

--- a/app/api/cv/generate/route.ts
+++ b/app/api/cv/generate/route.ts
@@ -183,16 +183,27 @@ export async function POST(req: NextRequest) {
       ON CONFLICT (id) DO NOTHING
     `;
 
+    // Build hyperlinks from personal info provided in the builder form
+    const builtHyperlinks: { text: string; url: string; context: string }[] = []
+    if (formData.personal.linkedin) {
+      builtHyperlinks.push({ text: 'LinkedIn', url: formData.personal.linkedin, context: 'contact' })
+    }
+    if (formData.personal.portfolio) {
+      builtHyperlinks.push({ text: 'Portfolio', url: formData.personal.portfolio, context: 'contact' })
+    }
+    const hyperlinksJson = JSON.stringify(builtHyperlinks)
+
     // Upsert CV row
     await db.$executeRaw`
-      INSERT INTO "CV" (id, user_id, raw_text, skills_json, clean_summary, embedding, updated_at)
+      INSERT INTO "CV" (id, user_id, raw_text, skills_json, clean_summary, embedding, hyperlinks_json, updated_at)
       VALUES (gen_random_uuid(), ${user.id}, ${cvText}, ${JSON.stringify(skills_json)}::jsonb,
-              ${clean_summary}, ${JSON.stringify(embedding)}::vector, now())
+              ${clean_summary}, ${JSON.stringify(embedding)}::vector, ${hyperlinksJson}, now())
       ON CONFLICT (user_id) DO UPDATE
         SET raw_text = EXCLUDED.raw_text,
             skills_json = EXCLUDED.skills_json,
             clean_summary = EXCLUDED.clean_summary,
             embedding = EXCLUDED.embedding,
+            hyperlinks_json = EXCLUDED.hyperlinks_json,
             updated_at = now()
     `;
 

--- a/app/api/cv/upload/route.ts
+++ b/app/api/cv/upload/route.ts
@@ -44,18 +44,83 @@ export async function POST(req: NextRequest) {
 
     const buffer = Buffer.from(await cvFile.arrayBuffer());
     let rawText: string;
+    const allLinks: { text: string; url: string; context: string }[] = [];
+
+    const URL_PATTERNS = [
+      {
+        regex: /github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)/g,
+        buildUrl: (m: RegExpExecArray) => `https://github.com/${m[1]}/${m[2]}`,
+        buildText: (m: RegExpExecArray) => `github.com/${m[1]}/${m[2]}`,
+      },
+      {
+        regex: /github\.com\/([a-zA-Z0-9_-]+)(?!\/[a-zA-Z0-9])/g,
+        buildUrl: (m: RegExpExecArray) => `https://github.com/${m[1]}`,
+        buildText: (m: RegExpExecArray) => `github.com/${m[1]}`,
+      },
+      {
+        regex: /linkedin\.com\/in\/([a-zA-Z0-9_-]+)/g,
+        buildUrl: (m: RegExpExecArray) => `https://linkedin.com/in/${m[1]}`,
+        buildText: (m: RegExpExecArray) => `linkedin.com/in/${m[1]}`,
+      },
+      {
+        regex: /https?:\/\/(?!linkedin|github)[^\s,;)>\]'"]+/g,
+        buildUrl: (m: RegExpExecArray) => m[0],
+        buildText: (m: RegExpExecArray) => m[0],
+      },
+    ];
+
+    const scanTextForUrls = (text: string) => {
+      for (const pattern of URL_PATTERNS) {
+        const regex = new RegExp(pattern.regex.source, "g");
+        let m: RegExpExecArray | null;
+        while ((m = regex.exec(text)) !== null) {
+          const url = pattern.buildUrl(m);
+          const txt = pattern.buildText(m);
+          if (!allLinks.some((l) => l.url === url)) {
+            allLinks.push({ text: txt, url, context: "inline" });
+          }
+        }
+      }
+    };
 
     if (isPdf) {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const pdfParse: (buf: Buffer) => Promise<{ text: string }> = require("pdf-parse");
       const result = await pdfParse(buffer);
       rawText = result.text;
+      // PDFs lose all hyperlinks — detect via regex only
+      scanTextForUrls(rawText);
     } else {
       // .docx
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const mammoth = require("mammoth");
-      const result = await mammoth.extractRawText({ buffer });
-      rawText = result.value;
+      const [htmlResult, rawResult] = await Promise.all([
+        mammoth.convertToHtml({ buffer }),
+        mammoth.extractRawText({ buffer }),
+      ]);
+      rawText = rawResult.value;
+
+      // Method 1: extract anchor hrefs from HTML output
+      const linkRegex = /<a[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/g;
+      const html: string = htmlResult.value;
+      let match: RegExpExecArray | null;
+      while ((match = linkRegex.exec(html)) !== null) {
+        const url = match[1];
+        const text = match[2].trim();
+        if (url.startsWith("mailto:")) continue;
+        const before = html.substring(Math.max(0, match.index - 200), match.index).toLowerCase();
+        const context =
+          before.includes("project") ? "project" :
+          before.includes("experience") ? "experience" :
+          before.includes("education") ? "education" :
+          "contact";
+        if (!allLinks.some((l) => l.url === url)) {
+          allLinks.push({ text, url, context });
+        }
+      }
+
+      // Method 2: detect raw URLs as fallback
+      scanTextForUrls(rawText);
     }
 
     // Send to Python service for Claude extraction + embedding
@@ -87,15 +152,17 @@ export async function POST(req: NextRequest) {
     `;
 
     // Upsert CV row (one CV per user)
+    const hyperlinksJson = JSON.stringify(allLinks);
     await db.$executeRaw`
-      INSERT INTO "CV" (id, user_id, raw_text, skills_json, clean_summary, embedding, updated_at)
+      INSERT INTO "CV" (id, user_id, raw_text, skills_json, clean_summary, embedding, hyperlinks_json, updated_at)
       VALUES (gen_random_uuid(), ${user.id}, ${rawText}, ${JSON.stringify(skills_json)}::jsonb,
-              ${clean_summary}, ${JSON.stringify(embedding)}::vector, now())
+              ${clean_summary}, ${JSON.stringify(embedding)}::vector, ${hyperlinksJson}, now())
       ON CONFLICT (user_id) DO UPDATE
         SET raw_text = EXCLUDED.raw_text,
             skills_json = EXCLUDED.skills_json,
             clean_summary = EXCLUDED.clean_summary,
             embedding = EXCLUDED.embedding,
+            hyperlinks_json = EXCLUDED.hyperlinks_json,
             updated_at = now()
     `;
 

--- a/app/api/cv/upload/route.ts
+++ b/app/api/cv/upload/route.ts
@@ -101,13 +101,15 @@ export async function POST(req: NextRequest) {
       rawText = rawResult.value;
 
       // Method 1: extract anchor hrefs from HTML output
-      const linkRegex = /<a[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/g;
+      // Use [\s\S]*? to handle nested tags like <a href="..."><span>text</span></a>
+      const linkRegex = /<a\s[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g;
       const html: string = htmlResult.value;
       let match: RegExpExecArray | null;
       while ((match = linkRegex.exec(html)) !== null) {
         const url = match[1];
-        const text = match[2].trim();
+        const text = match[2].replace(/<[^>]+>/g, "").trim();
         if (url.startsWith("mailto:")) continue;
+        if (!text && !url) continue;
         const before = html.substring(Math.max(0, match.index - 200), match.index).toLowerCase();
         const context =
           before.includes("project") ? "project" :
@@ -115,7 +117,7 @@ export async function POST(req: NextRequest) {
           before.includes("education") ? "education" :
           "contact";
         if (!allLinks.some((l) => l.url === url)) {
-          allLinks.push({ text, url, context });
+          allLinks.push({ text: text || url, url, context });
         }
       }
 

--- a/app/dashboard/onboarding/page.tsx
+++ b/app/dashboard/onboarding/page.tsx
@@ -193,10 +193,10 @@ export default function OnboardingPage() {
                 </div>
                 <div>
                   <p className="text-sm font-semibold text-gray-900">{isUpdate ? "Replace CV" : "Upload existing CV"}</p>
-                  <p className="text-xs text-gray-500 mt-0.5">PDF document</p>
+                  <p className="text-xs text-gray-500 mt-0.5">PDF or Word document (.pdf, .docx)</p>
                 </div>
                 <span className="text-xs font-medium border border-gray-300 px-3 py-1 rounded-lg group-hover:border-black transition-colors">
-                  {isUpdate ? "Upload new PDF" : "Upload CV"}
+                  {isUpdate ? "Upload new CV" : "Upload CV"}
                 </span>
               </button>
 
@@ -231,7 +231,7 @@ export default function OnboardingPage() {
               <label className="block border-2 border-dashed rounded-lg p-8 text-center cursor-pointer hover:border-gray-400 transition-colors">
                 <input
                   type="file"
-                  accept=".pdf"
+                  accept=".pdf,.docx"
                   className="hidden"
                   onChange={(e) => {
                     const f = e.target.files?.[0];
@@ -244,7 +244,7 @@ export default function OnboardingPage() {
                   <span className="text-sm font-medium">{file.name}</span>
                 ) : (
                   <span className="text-sm text-gray-400">
-                    {isUpdate ? "Click to choose a new PDF (optional)" : "Click to choose a PDF"}
+                    {isUpdate ? "Click to choose a new PDF or Word file (optional)" : "Click to choose a PDF or Word file (.docx)"}
                   </span>
                 )}
               </label>

--- a/lib/generate-cv.ts
+++ b/lib/generate-cv.ts
@@ -1,11 +1,99 @@
 import {
   Document, Packer, Paragraph, TextRun, AlignmentType,
-  BorderStyle, LevelFormat,
+  BorderStyle, LevelFormat, ExternalHyperlink, UnderlineType,
 } from 'docx'
+
+interface CVHyperlink {
+  text: string
+  url: string
+  context: string
+}
+
+// URL patterns used as a fallback when stored hyperlinks don't cover a line
+const LINE_URL_PATTERNS: { regex: RegExp; buildUrl: (m: RegExpMatchArray) => string }[] = [
+  {
+    regex: /github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)/,
+    buildUrl: (m) => `https://github.com/${m[1]}/${m[2]}`,
+  },
+  {
+    regex: /github\.com\/([a-zA-Z0-9_-]+)/,
+    buildUrl: (m) => `https://github.com/${m[1]}`,
+  },
+  {
+    regex: /linkedin\.com\/in\/([a-zA-Z0-9_-]+)/,
+    buildUrl: (m) => `https://linkedin.com/in/${m[1]}`,
+  },
+  {
+    regex: /https?:\/\/[^\s,;)>\]'"]+/,
+    buildUrl: (m) => m[0],
+  },
+]
+
+function linkifyLine(
+  lineText: string,
+  hyperlinks: CVHyperlink[],
+  runStyle: { font: string; size: number; color: string }
+): (TextRun | ExternalHyperlink)[] {
+  // Build combined link list: stored links + pattern-detected ones from this line
+  const allLinks: CVHyperlink[] = [...hyperlinks]
+  for (const pattern of LINE_URL_PATTERNS) {
+    const m = lineText.match(pattern.regex)
+    if (m) {
+      const url = pattern.buildUrl(m)
+      if (!allLinks.some((l) => l.url === url)) {
+        allLinks.push({ text: m[0], url, context: 'inline' })
+      }
+    }
+  }
+
+  if (!allLinks.length) {
+    return [new TextRun({ text: lineText, ...runStyle })]
+  }
+
+  const runs: (TextRun | ExternalHyperlink)[] = []
+  let remaining = lineText
+
+  for (const link of allLinks) {
+    // Try matching by anchor text first, then by raw URL
+    const searchTerms = [link.text, link.url].filter(Boolean)
+    let found = false
+
+    for (const term of searchTerms) {
+      const idx = remaining.toLowerCase().indexOf(term.toLowerCase())
+      if (idx === -1) continue
+
+      if (idx > 0) {
+        runs.push(new TextRun({ text: remaining.substring(0, idx), ...runStyle }))
+      }
+      runs.push(new ExternalHyperlink({
+        link: link.url,
+        children: [new TextRun({
+          text: remaining.substring(idx, idx + term.length),
+          font: runStyle.font,
+          size: runStyle.size,
+          color: '1D4ED8',
+          underline: { type: UnderlineType.SINGLE },
+        })],
+      }))
+      remaining = remaining.substring(idx + term.length)
+      found = true
+      break
+    }
+
+    if (!found) continue
+  }
+
+  if (remaining) {
+    runs.push(new TextRun({ text: remaining, ...runStyle }))
+  }
+
+  return runs.length > 0 ? runs : [new TextRun({ text: lineText, ...runStyle })]
+}
 
 export async function generateCVDocx(
   cvText: string,
-  _jobTitle: string = 'CV'
+  _jobTitle: string = 'CV',
+  hyperlinks: CVHyperlink[] = []
 ): Promise<Buffer> {
 
   const FONT = 'Calibri'
@@ -16,10 +104,8 @@ export async function generateCVDocx(
 
   const children: Paragraph[] = []
 
-  // Parse the CV text into structured sections
   const lines = cvText.split('\n').map(l => l.trim()).filter(Boolean)
 
-  // Known section headers to detect
   const SECTION_HEADERS = [
     'summary', 'work experience', 'experience', 'education',
     'skills', 'projects', 'languages', 'certifications',
@@ -45,7 +131,7 @@ export async function generateCVDocx(
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
 
-    // First line = candidate name — large, bold, centered
+    // First line = candidate name — large, bold, centered (never a link)
     if (isFirstLine) {
       children.push(new Paragraph({
         alignment: AlignmentType.CENTER,
@@ -53,7 +139,7 @@ export async function generateCVDocx(
         children: [new TextRun({
           text: line,
           font: FONT,
-          size: 32,        // 16pt
+          size: 32,
           bold: true,
           color: COLOR_NAME,
         })]
@@ -69,18 +155,13 @@ export async function generateCVDocx(
       children.push(new Paragraph({
         alignment: AlignmentType.CENTER,
         spacing: { before: 0, after: 120 },
-        children: [new TextRun({
-          text: line,
-          font: FONT,
-          size: 18,        // 9pt
-          color: COLOR_CONTACT,
-        })]
+        children: linkifyLine(line, hyperlinks, { font: FONT, size: 18, color: COLOR_CONTACT }),
       }))
       isSecondLine = false
       continue
     }
 
-    // Section headers — blue, bold, with bottom border line
+    // Section headers — never links
     if (isSectionHeader(line)) {
       children.push(new Paragraph({
         spacing: { before: 160, after: 0 },
@@ -95,27 +176,22 @@ export async function generateCVDocx(
         children: [new TextRun({
           text: line.toUpperCase(),
           font: FONT,
-          size: 20,        // 10pt
+          size: 20,
           bold: true,
           color: COLOR_SECTION,
-          characterSpacing: 40,  // slight letter spacing
+          characterSpacing: 40,
         })]
       }))
       continue
     }
 
-    // Bullet points — proper docx bullets, not unicode
+    // Bullet points
     if (isBullet(line)) {
       const text = line.replace(/^[-•*o]\s+/, '')
       children.push(new Paragraph({
         numbering: { reference: 'cv-bullets', level: 0 },
         spacing: { before: 0, after: 40 },
-        children: [new TextRun({
-          text,
-          font: FONT,
-          size: 19,        // 9.5pt
-          color: COLOR_BODY,
-        })]
+        children: linkifyLine(text, hyperlinks, { font: FONT, size: 19, color: COLOR_BODY }),
       }))
       continue
     }
@@ -145,12 +221,7 @@ export async function generateCVDocx(
     // Regular body text
     children.push(new Paragraph({
       spacing: { before: 0, after: 40 },
-      children: [new TextRun({
-        text: line,
-        font: FONT,
-        size: 19,          // 9.5pt
-        color: COLOR_BODY,
-      })]
+      children: linkifyLine(line, hyperlinks, { font: FONT, size: 19, color: COLOR_BODY }),
     }))
   }
 

--- a/lib/generate-cv.ts
+++ b/lib/generate-cv.ts
@@ -9,85 +9,98 @@ interface CVHyperlink {
   context: string
 }
 
-// URL patterns used as a fallback when stored hyperlinks don't cover a line
-const LINE_URL_PATTERNS: { regex: RegExp; buildUrl: (m: RegExpMatchArray) => string }[] = [
+// URL patterns used as fallback detection directly on line text
+const LINE_URL_PATTERNS: { regex: RegExp; buildUrl: (m: RegExpExecArray) => string }[] = [
   {
-    regex: /github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)/,
+    regex: /github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)/g,
     buildUrl: (m) => `https://github.com/${m[1]}/${m[2]}`,
   },
   {
-    regex: /github\.com\/([a-zA-Z0-9_-]+)/,
+    regex: /github\.com\/([a-zA-Z0-9_-]+)/g,
     buildUrl: (m) => `https://github.com/${m[1]}`,
   },
   {
-    regex: /linkedin\.com\/in\/([a-zA-Z0-9_-]+)/,
+    regex: /linkedin\.com\/in\/([a-zA-Z0-9_-]+)/g,
     buildUrl: (m) => `https://linkedin.com/in/${m[1]}`,
   },
   {
-    regex: /https?:\/\/[^\s,;)>\]'"]+/,
+    regex: /https?:\/\/[^\s,;)>\]'"]+/g,
     buildUrl: (m) => m[0],
   },
 ]
+
+interface LinkMatch {
+  start: number
+  end: number
+  url: string
+  displayText: string
+}
 
 function linkifyLine(
   lineText: string,
   hyperlinks: CVHyperlink[],
   runStyle: { font: string; size: number; color: string }
 ): (TextRun | ExternalHyperlink)[] {
-  // Build combined link list: stored links + pattern-detected ones from this line
-  const allLinks: CVHyperlink[] = [...hyperlinks]
-  for (const pattern of LINE_URL_PATTERNS) {
-    const m = lineText.match(pattern.regex)
-    if (m) {
-      const url = pattern.buildUrl(m)
-      if (!allLinks.some((l) => l.url === url)) {
-        allLinks.push({ text: m[0], url, context: 'inline' })
+  const matches: LinkMatch[] = []
+
+  // Find positions of stored hyperlinks in this line
+  for (const link of hyperlinks) {
+    // Try display text first, then raw URL
+    for (const term of [link.text, link.url].filter(Boolean)) {
+      const idx = lineText.toLowerCase().indexOf(term.toLowerCase())
+      if (idx !== -1) {
+        matches.push({ start: idx, end: idx + term.length, url: link.url, displayText: lineText.substring(idx, idx + term.length) })
+        break
       }
     }
   }
 
-  if (!allLinks.length) {
+  // Find positions of pattern-detected URLs (fallback for plain-text URLs)
+  for (const pattern of LINE_URL_PATTERNS) {
+    const regex = new RegExp(pattern.regex.source, 'g')
+    let m: RegExpExecArray | null
+    while ((m = regex.exec(lineText)) !== null) {
+      const url = pattern.buildUrl(m)
+      const start = m.index
+      const end = start + m[0].length
+      // Skip if this range overlaps an already-found match
+      if (!matches.some((e) => e.start < end && e.end > start)) {
+        matches.push({ start, end, url, displayText: m[0] })
+      }
+    }
+  }
+
+  if (!matches.length) {
     return [new TextRun({ text: lineText, ...runStyle })]
   }
 
+  // Process in line order so multiple links per line all get rendered
+  matches.sort((a, b) => a.start - b.start)
+
   const runs: (TextRun | ExternalHyperlink)[] = []
-  let remaining = lineText
-
-  for (const link of allLinks) {
-    // Try matching by anchor text first, then by raw URL
-    const searchTerms = [link.text, link.url].filter(Boolean)
-    let found = false
-
-    for (const term of searchTerms) {
-      const idx = remaining.toLowerCase().indexOf(term.toLowerCase())
-      if (idx === -1) continue
-
-      if (idx > 0) {
-        runs.push(new TextRun({ text: remaining.substring(0, idx), ...runStyle }))
-      }
-      runs.push(new ExternalHyperlink({
-        link: link.url,
-        children: [new TextRun({
-          text: remaining.substring(idx, idx + term.length),
-          font: runStyle.font,
-          size: runStyle.size,
-          color: '1D4ED8',
-          underline: { type: UnderlineType.SINGLE },
-        })],
-      }))
-      remaining = remaining.substring(idx + term.length)
-      found = true
-      break
+  let pos = 0
+  for (const match of matches) {
+    if (match.start < pos) continue  // overlapping, already consumed
+    if (match.start > pos) {
+      runs.push(new TextRun({ text: lineText.substring(pos, match.start), ...runStyle }))
     }
-
-    if (!found) continue
+    runs.push(new ExternalHyperlink({
+      link: match.url,
+      children: [new TextRun({
+        text: match.displayText,
+        font: runStyle.font,
+        size: runStyle.size,
+        color: '1D4ED8',
+        underline: { type: UnderlineType.SINGLE },
+      })],
+    }))
+    pos = match.end
+  }
+  if (pos < lineText.length) {
+    runs.push(new TextRun({ text: lineText.substring(pos), ...runStyle }))
   }
 
-  if (remaining) {
-    runs.push(new TextRun({ text: remaining, ...runStyle }))
-  }
-
-  return runs.length > 0 ? runs : [new TextRun({ text: lineText, ...runStyle })]
+  return runs
 }
 
 export async function generateCVDocx(

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,13 +28,14 @@ model User {
 }
 
 model CV {
-  id            String                      @id @default(uuid())
-  user_id       String
-  raw_text      String
-  skills_json   Json?
-  clean_summary String?
-  embedding     Unsupported("vector(384)")?
-  updated_at    DateTime                    @updatedAt
+  id              String                      @id @default(uuid())
+  user_id         String
+  raw_text        String
+  skills_json     Json?
+  clean_summary   String?
+  embedding       Unsupported("vector(384)")?
+  hyperlinks_json String?                     @default("[]")
+  updated_at      DateTime                    @updatedAt
 
   user User @relation(fields: [user_id], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
## What this fixes
Links in uploaded CVs were lost during text extraction. Downloaded CVs showed LinkedIn/GitHub as plain unclickable text.

## What's covered
- LinkedIn profile links
- GitHub profile links
- GitHub repository links in Projects section
- Portfolio/personal website URLs
- Any https:// URL written anywhere in the CV

## How it works
1. **Upload**: mammoth extracts anchor hrefs from .docx HTML output. Regex patterns detect raw URLs as fallback (for PDFs and plain-text URLs). All links stored in `hyperlinks_json` on the `cvs` table.
2. **Download**: `linkifyLine()` scans each line of CV text, matches against stored links and detects new URL patterns, renders matches as `ExternalHyperlink` in the .docx output.
3. **CV builder**: LinkedIn/GitHub from the personal info form are saved as hyperlinks automatically.

## How to test
- Upload a .docx CV with LinkedIn/GitHub links → check Supabase `cvs` table `hyperlinks_json` column has the extracted URLs
- Download tailored CV → open in Word/Google Docs → LinkedIn and GitHub should be blue clickable links
- Test with PDF upload → URL patterns should still detect `github.com` and `linkedin.com` as clickable links

Closes #32