### PR TITLE
Fix CV download formatting — alignment, bullets, bold names, one page

### DIFF
--- a/lib/generate-cv.ts
+++ b/lib/generate-cv.ts
@@ -1,6 +1,7 @@
 import {
   Document, Packer, Paragraph, TextRun, AlignmentType,
   BorderStyle, LevelFormat, ExternalHyperlink, UnderlineType,
+  LineRuleType,
 } from 'docx'
 
 interface CVHyperlink {
@@ -9,7 +10,6 @@ interface CVHyperlink {
   context: string
 }
 
-// URL patterns used as fallback detection directly on line text
 const LINE_URL_PATTERNS: { regex: RegExp; buildUrl: (m: RegExpExecArray) => string }[] = [
   {
     regex: /github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)/g,
@@ -39,23 +39,25 @@ interface LinkMatch {
 function linkifyLine(
   lineText: string,
   hyperlinks: CVHyperlink[],
-  runStyle: { font: string; size: number; color: string }
+  runStyle: { font: string; size: number; color: string; bold?: boolean }
 ): (TextRun | ExternalHyperlink)[] {
   const matches: LinkMatch[] = []
 
-  // Find positions of stored hyperlinks in this line
   for (const link of hyperlinks) {
-    // Try display text first, then raw URL
     for (const term of [link.text, link.url].filter(Boolean)) {
       const idx = lineText.toLowerCase().indexOf(term.toLowerCase())
       if (idx !== -1) {
-        matches.push({ start: idx, end: idx + term.length, url: link.url, displayText: lineText.substring(idx, idx + term.length) })
+        matches.push({
+          start: idx,
+          end: idx + term.length,
+          url: link.url,
+          displayText: lineText.substring(idx, idx + term.length),
+        })
         break
       }
     }
   }
 
-  // Find positions of pattern-detected URLs (fallback for plain-text URLs)
   for (const pattern of LINE_URL_PATTERNS) {
     const regex = new RegExp(pattern.regex.source, 'g')
     let m: RegExpExecArray | null
@@ -63,7 +65,6 @@ function linkifyLine(
       const url = pattern.buildUrl(m)
       const start = m.index
       const end = start + m[0].length
-      // Skip if this range overlaps an already-found match
       if (!matches.some((e) => e.start < end && e.end > start)) {
         matches.push({ start, end, url, displayText: m[0] })
       }
@@ -71,18 +72,21 @@ function linkifyLine(
   }
 
   if (!matches.length) {
-    return [new TextRun({ text: lineText, ...runStyle })]
+    return [new TextRun({ text: lineText, ...runStyle, rightToLeft: false })]
   }
 
-  // Process in line order so multiple links per line all get rendered
   matches.sort((a, b) => a.start - b.start)
 
   const runs: (TextRun | ExternalHyperlink)[] = []
   let pos = 0
   for (const match of matches) {
-    if (match.start < pos) continue  // overlapping, already consumed
+    if (match.start < pos) continue
     if (match.start > pos) {
-      runs.push(new TextRun({ text: lineText.substring(pos, match.start), ...runStyle }))
+      runs.push(new TextRun({
+        text: lineText.substring(pos, match.start),
+        ...runStyle,
+        rightToLeft: false,
+      }))
     }
     runs.push(new ExternalHyperlink({
       link: match.url,
@@ -92,15 +96,69 @@ function linkifyLine(
         size: runStyle.size,
         color: '1D4ED8',
         underline: { type: UnderlineType.SINGLE },
+        rightToLeft: false,
       })],
     }))
     pos = match.end
   }
   if (pos < lineText.length) {
-    runs.push(new TextRun({ text: lineText.substring(pos), ...runStyle }))
+    runs.push(new TextRun({
+      text: lineText.substring(pos),
+      ...runStyle,
+      rightToLeft: false,
+    }))
   }
 
   return runs
+}
+
+// Bold the project/item name before " – " or " - " in bullet lines
+function buildBulletRuns(
+  text: string,
+  hyperlinks: CVHyperlink[],
+  runStyle: { font: string; size: number; color: string }
+): (TextRun | ExternalHyperlink)[] {
+  const dashIdx = text.indexOf(' – ')   // en-dash
+  const emDashIdx = text.indexOf(' — ')  // em-dash
+  const regularDashIdx = text.indexOf(' - ')
+
+  const splitIndex =
+    dashIdx !== -1 ? dashIdx :
+    emDashIdx !== -1 ? emDashIdx :
+    regularDashIdx !== -1 ? regularDashIdx :
+    -1
+
+  if (splitIndex === -1) {
+    return linkifyLine(text, hyperlinks, runStyle)
+  }
+
+  const separator =
+    dashIdx !== -1 ? ' – ' :
+    emDashIdx !== -1 ? ' — ' :
+    ' - '
+
+  const beforeDash = text.substring(0, splitIndex)
+  const afterDash = text.substring(splitIndex + separator.length)
+
+  return [
+    new TextRun({
+      text: beforeDash,
+      font: runStyle.font,
+      size: runStyle.size,
+      color: runStyle.color,
+      bold: true,
+      rightToLeft: false,
+    }),
+    new TextRun({
+      text: separator,
+      font: runStyle.font,
+      size: runStyle.size,
+      color: runStyle.color,
+      bold: false,
+      rightToLeft: false,
+    }),
+    ...linkifyLine(afterDash, hyperlinks, { ...runStyle, bold: false }),
+  ]
 }
 
 export async function generateCVDocx(
@@ -110,10 +168,12 @@ export async function generateCVDocx(
 ): Promise<Buffer> {
 
   const FONT = 'Calibri'
-  const COLOR_NAME = '1F2937'      // near black
-  const COLOR_SECTION = '1F2937'   // near black for section headers
-  const COLOR_BODY = '374151'      // dark gray for body text
-  const COLOR_CONTACT = '6B7280'   // medium gray for contact line
+  const COLOR_NAME    = '1F2937'   // near black
+  const COLOR_SECTION = '2563EB'   // blue for section headers
+  const COLOR_BODY    = '374151'   // dark gray
+  const COLOR_CONTACT = '6B7280'   // medium gray
+
+  const LINE_SPACING = { line: 220, lineRule: LineRuleType.AUTO }
 
   const children: Paragraph[] = []
 
@@ -122,20 +182,20 @@ export async function generateCVDocx(
   const SECTION_HEADERS = [
     'summary', 'work experience', 'experience', 'education',
     'skills', 'projects', 'languages', 'certifications',
-    'achievements', 'contact'
+    'achievements', 'contact', 'hackathon', 'hackathons',
+    'volunteer', 'awards', 'publications',
   ]
 
   const isSectionHeader = (line: string) =>
-    SECTION_HEADERS.some(h => line.toLowerCase() === h ||
-      line.toLowerCase().startsWith(h + ':'))
+    SECTION_HEADERS.some(h =>
+      line.toLowerCase() === h || line.toLowerCase().startsWith(h + ':')
+    )
 
   const isBullet = (line: string) =>
     line.startsWith('- ') || line.startsWith('• ') ||
     line.startsWith('* ') || line.startsWith('o ')
 
-  const isContactLine = (line: string) =>
-    line.includes('@') || line.includes('|') ||
-    line.includes('+') || !!line.match(/\d{3}/)
+  const isSubBullet = (line: string) => line.startsWith('o ')
 
   let isFirstLine = true
   let isSecondLine = false
@@ -144,18 +204,20 @@ export async function generateCVDocx(
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
 
-    // First line = candidate name — large, bold, centered (never a link)
+    // ── Line 1: candidate name ──────────────────────────────────────────────
     if (isFirstLine) {
       children.push(new Paragraph({
         alignment: AlignmentType.CENTER,
-        spacing: { before: 0, after: 40 },
+        bidirectional: false,
+        spacing: { before: 0, after: 40, ...LINE_SPACING },
         children: [new TextRun({
           text: line,
           font: FONT,
-          size: 32,
+          size: 28,
           bold: true,
           color: COLOR_NAME,
-        })]
+          rightToLeft: false,
+        })],
       }))
       isFirstLine = false
       isSecondLine = true
@@ -163,28 +225,31 @@ export async function generateCVDocx(
       continue
     }
 
-    // Contact line (email, phone, LinkedIn)
-    if (isSecondLine || (nameAdded && isContactLine(line))) {
+    // ── Line 2: contact info ────────────────────────────────────────────────
+    if (isSecondLine && nameAdded) {
       children.push(new Paragraph({
         alignment: AlignmentType.CENTER,
-        spacing: { before: 0, after: 120 },
-        children: linkifyLine(line, hyperlinks, { font: FONT, size: 18, color: COLOR_CONTACT }),
+        bidirectional: false,
+        spacing: { before: 0, after: 100, ...LINE_SPACING },
+        children: linkifyLine(line, hyperlinks, { font: FONT, size: 17, color: COLOR_CONTACT }),
       }))
       isSecondLine = false
       continue
     }
 
-    // Section headers — never links
+    // ── Section headers ─────────────────────────────────────────────────────
     if (isSectionHeader(line)) {
       children.push(new Paragraph({
-        spacing: { before: 160, after: 0 },
+        alignment: AlignmentType.LEFT,
+        bidirectional: false,
+        spacing: { before: 100, after: 50, ...LINE_SPACING },
         border: {
           bottom: {
             color: COLOR_SECTION,
             style: BorderStyle.SINGLE,
             size: 6,
             space: 4,
-          }
+          },
         },
         children: [new TextRun({
           text: line.toUpperCase(),
@@ -193,88 +258,133 @@ export async function generateCVDocx(
           bold: true,
           color: COLOR_SECTION,
           characterSpacing: 40,
-        })]
+          rightToLeft: false,
+        })],
       }))
       continue
     }
 
-    // Bullet points
-    if (isBullet(line)) {
-      const text = line.replace(/^[-•*o]\s+/, '')
+    // ── Sub-bullets (o prefix) ──────────────────────────────────────────────
+    if (isSubBullet(line)) {
+      const text = line.replace(/^o\s+/, '')
       children.push(new Paragraph({
-        numbering: { reference: 'cv-bullets', level: 0 },
-        spacing: { before: 0, after: 40 },
-        children: linkifyLine(text, hyperlinks, { font: FONT, size: 19, color: COLOR_BODY }),
+        alignment: AlignmentType.LEFT,
+        bidirectional: false,
+        numbering: { reference: 'cv-sub-bullets', level: 0 },
+        spacing: { before: 0, after: 20, ...LINE_SPACING },
+        children: buildBulletRuns(text, hyperlinks, { font: FONT, size: 18, color: COLOR_BODY }),
       }))
       continue
     }
 
-    // Job title lines — detect by pattern (Title, Company · Date)
-    const isRoleHeader = line.includes('·') || line.includes('–') ||
+    // ── Main bullets ────────────────────────────────────────────────────────
+    if (isBullet(line)) {
+      const text = line.replace(/^[-•*]\s+/, '')
+      children.push(new Paragraph({
+        alignment: AlignmentType.LEFT,
+        bidirectional: false,
+        numbering: { reference: 'cv-main-bullets', level: 0 },
+        spacing: { before: 0, after: 20, ...LINE_SPACING },
+        children: buildBulletRuns(text, hyperlinks, { font: FONT, size: 18, color: COLOR_BODY }),
+      }))
+      continue
+    }
+
+    // ── Role/date header lines (Title · Company – Date) ─────────────────────
+    const isRoleHeader =
+      line.includes('·') ||
+      (line.includes('–') && !!line.match(/\d{4}/)) ||
       (line.includes('-') && !!line.match(/\d{4}/))
 
     if (isRoleHeader) {
       const parts = line.split(/[·–]/)
-      const runParts = parts.flatMap((part, idx) => [
-        new TextRun({
+      const runParts = parts.flatMap((part, idx) =>
+        [new TextRun({
           text: idx === 0 ? part.trim() : ' · ' + part.trim(),
           font: FONT,
-          size: 19,
+          size: 18,
           bold: idx === 0,
           color: idx === 0 ? COLOR_NAME : COLOR_CONTACT,
-        })
-      ])
+          rightToLeft: false,
+        })]
+      )
       children.push(new Paragraph({
-        spacing: { before: 100, after: 20 },
+        alignment: AlignmentType.LEFT,
+        bidirectional: false,
+        spacing: { before: 80, after: 20, ...LINE_SPACING },
         children: runParts,
       }))
       continue
     }
 
-    // Regular body text
+    // ── Regular body text ───────────────────────────────────────────────────
     children.push(new Paragraph({
-      spacing: { before: 0, after: 40 },
-      children: linkifyLine(line, hyperlinks, { font: FONT, size: 19, color: COLOR_BODY }),
+      alignment: AlignmentType.LEFT,
+      bidirectional: false,
+      spacing: { before: 0, after: 30, ...LINE_SPACING },
+      children: linkifyLine(line, hyperlinks, { font: FONT, size: 18, color: COLOR_BODY }),
     }))
   }
 
   const doc = new Document({
     numbering: {
-      config: [{
-        reference: 'cv-bullets',
-        levels: [{
-          level: 0,
-          format: LevelFormat.BULLET,
-          text: '•',
-          alignment: AlignmentType.LEFT,
-          style: {
-            paragraph: {
-              indent: { left: 360, hanging: 180 },
-              spacing: { before: 0, after: 40 },
+      config: [
+        {
+          reference: 'cv-main-bullets',
+          levels: [{
+            level: 0,
+            format: LevelFormat.BULLET,
+            text: '•',
+            alignment: AlignmentType.LEFT,
+            style: {
+              paragraph: {
+                indent: { left: 360, hanging: 180 },
+                bidirectional: false,
+              },
+              run: {
+                font: FONT,
+                size: 18,
+                color: COLOR_BODY,
+              },
             },
-            run: {
-              font: FONT,
-              size: 19,
-              color: COLOR_BODY,
-            }
-          }
-        }]
-      }]
+          }],
+        },
+        {
+          reference: 'cv-sub-bullets',
+          levels: [{
+            level: 0,
+            format: LevelFormat.BULLET,
+            text: '○',
+            alignment: AlignmentType.LEFT,
+            style: {
+              paragraph: {
+                indent: { left: 720, hanging: 180 },
+                bidirectional: false,
+              },
+              run: {
+                font: FONT,
+                size: 18,
+                color: COLOR_BODY,
+              },
+            },
+          }],
+        },
+      ],
     },
     sections: [{
       properties: {
         page: {
           size: { width: 12240, height: 15840 },  // US Letter
           margin: {
-            top: 900,
-            bottom: 900,
-            left: 1080,
-            right: 1080,
-          }
-        }
+            top: 700,
+            bottom: 700,
+            left: 900,
+            right: 900,
+          },
+        },
       },
       children,
-    }]
+    }],
   })
 
   return await Packer.toBuffer(doc)


### PR DESCRIPTION
## Problems fixed
- **RTL bug**: Hebrew text in Languages section was causing Word to flip entire document right-to-left
- **Alignment**: only name and contact centered, everything else explicitly LEFT aligned
- **Bullets**: two indent levels preserved (main `•` and sub `○`)
- **Project names**: bold before the dash separator (e.g. **Fursan** – Horse Marketplace…)
- **Page count**: spacing and margins tightened to fit on one page

## Root cause
Hebrew characters triggered Word's automatic RTL detection. Fixed by adding `bidirectional: false` and `rightToLeft: false` to every paragraph and text run in the document.

## Changes in `lib/generate-cv.ts`
- `bidirectional: false` on every `Paragraph`
- `rightToLeft: false` on every `TextRun`
- `AlignmentType.LEFT` on all content except name (line 1) and contact (line 2)
- Two numbering configs: `cv-main-bullets` (left: 360) and `cv-sub-bullets` (left: 720)
- `buildBulletRuns()` helper — detects ` – ` / ` - ` and renders name before dash as bold
- Margins: top/bottom 700, left/right 900 twips
- Font sizes: name 28, section headers 20, body/bullets 18, contact 17
- Line spacing: 220 auto on all paragraphs
- Section headers: `COLOR_SECTION = '2563EB'` (blue), left-aligned

## How to test
Upload a CV with Hebrew content → download .docx → open in Word → verify:
- [ ] Name centered, bold
- [ ] Contact line centered with clickable links
- [ ] All body text left-aligned (not right-aligned)
- [ ] Section headers left-aligned, blue underline
- [ ] Main bullets `•` at left margin
- [ ] Sub-bullets `○` indented further right
- [ ] Project names bold before dash
- [ ] Fits on one page
- [ ] Hebrew in Languages section displays correctly, doesn't flip alignment

Closes #38