### PR TITLE
fix: restore job matches — widen 7-day filter to 30 days + scheduler recovery

### DIFF
--- a/ai-service/routes/matching.py
+++ b/ai-service/routes/matching.py
@@ -70,7 +70,7 @@ async def _vector_search(conn, user_id: str) -> tuple[list, dict | None]:
                1 - (j.embedding <=> cv.embedding::vector) AS similarity
         FROM "Job" j, "CV" cv
         WHERE cv.user_id = $1
-          AND j.scraped_at > NOW() - INTERVAL '7 days'
+          AND j.scraped_at > NOW() - INTERVAL '30 days'
           AND j.id NOT IN (
             SELECT job_id FROM "UserJobInteraction" WHERE user_id = $1
           )

--- a/ai-service/scheduler.py
+++ b/ai-service/scheduler.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import UTC
 
 import asyncpg
 import httpx
@@ -62,11 +63,38 @@ async def _run_match_all():
             logger.exception("[scheduler] Match failed for user %s", user_id)
 
 
+async def _recovery_scrape_if_stale():
+    """Run an immediate scrape on startup if the newest job is older than 24 hours."""
+    try:
+        database_url = os.environ["DATABASE_URL"]
+        conn = await asyncpg.connect(database_url)
+        try:
+            last_scraped = await conn.fetchval('SELECT MAX(scraped_at) FROM "Job"')
+        finally:
+            await conn.close()
+
+        from datetime import datetime
+        now = datetime.now(UTC)
+        if last_scraped is None or (now - last_scraped.replace(tzinfo=UTC)).total_seconds() > 86400:
+            age = "never" if last_scraped is None else f"{(now - last_scraped.replace(tzinfo=UTC)).days}d ago"
+            logger.info("[scheduler] Recovery scrape triggered — last scrape was %s", age)
+            await _run_scrape()
+        else:
+            logger.info("[scheduler] No recovery scrape needed — last scrape was recent")
+    except Exception:
+        logger.exception("[scheduler] Recovery scrape check failed")
+
+
 def start_scheduler():
     scheduler.add_job(_run_scrape, CronTrigger(hour=5, minute=0, timezone="UTC"), id="daily_scrape")
     scheduler.add_job(_run_match_all, CronTrigger(hour=6, minute=0, timezone="UTC"), id="daily_match")
+    # Fire a one-shot recovery check 5 seconds after startup so the event loop is ready
+    from datetime import datetime, timedelta
+    scheduler.add_job(_recovery_scrape_if_stale, "date",
+                      run_date=datetime.now(UTC) + timedelta(seconds=5),
+                      id="startup_recovery")
     scheduler.start()
-    logger.info("[scheduler] Started — scrape@05:00 UTC, match@06:00 UTC")
+    logger.info("[scheduler] Started — scrape@05:00 UTC, match@06:00 UTC, recovery check in 5s")
 
 
 def stop_scheduler():


### PR DESCRIPTION
Fixes #42

## Problem
Dashboard showed **"No new matches today"** despite 1,677 jobs in the database. The scraper had not run since 2026-04-29 (10 days ago), so every job was excluded by the `7-day` window in `_vector_search`. Clicking Refresh re-ran the full pipeline but still returned `[]` for the same reason.

## Changes

### `ai-service/routes/matching.py`
- `INTERVAL '7 days'` → `INTERVAL '30 days'` in the vector search query.  
  A 7-day window means a single week of scheduler downtime silently empties all results. 30 days gives headroom while still excluding very stale listings.

### `ai-service/scheduler.py`
- Added `_recovery_scrape_if_stale()`: on service startup, queries `MAX(scraped_at)`. If the newest job is older than 24 hours, it triggers an immediate scrape (5-second delay so the event loop is ready) instead of waiting until the next 05:00 UTC window.  
  APScheduler does not backfill missed cron runs, so a service restart after a missed window would otherwise leave the DB stale until the next day.

## Test plan
- [ ] Restart the Python service → confirm recovery scrape fires within 5 seconds (check uvicorn logs)
- [ ] Hit `GET /api/match?refresh=true` → confirm jobs are returned again
- [ ] Verify dashboard "My Matches" tab shows results
- [ ] After a fresh scrape completes, verify `match_cache` is repopulated

🤖 Generated with [Claude Code](https://claude.com/claude-code)