### PR TITLE
Fix: remove applied jobs from dashboard

### DIFF
--- a/ai-service/routes/matching.py
+++ b/ai-service/routes/matching.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 
@@ -73,6 +74,9 @@ async def _vector_search(conn, user_id: str) -> tuple[list, dict | None]:
           AND j.scraped_at > NOW() - INTERVAL '30 days'
           AND j.id NOT IN (
             SELECT job_id FROM "UserJobInteraction" WHERE user_id = $1
+          )
+          AND j.id NOT IN (
+            SELECT job_id FROM "Application" WHERE user_id = $1
           )
           AND 1 - (j.embedding <=> cv.embedding::vector) > 0.50
         ORDER BY j.embedding <=> cv.embedding::vector
@@ -238,12 +242,18 @@ async def match_jobs(req: MatchRequest):
         if not req.force_refresh:
             cached = await _get_db_cache(conn, req.user_id)
             if cached is not None:
-                dismissed = await conn.fetch(
-                    'SELECT job_id FROM "UserJobInteraction" WHERE user_id = $1',
-                    req.user_id,
+                dismissed, applied = await asyncio.gather(
+                    conn.fetch(
+                        'SELECT job_id FROM "UserJobInteraction" WHERE user_id = $1',
+                        req.user_id,
+                    ),
+                    conn.fetch(
+                        'SELECT job_id FROM "Application" WHERE user_id = $1',
+                        req.user_id,
+                    ),
                 )
-                dismissed_ids = {r["job_id"] for r in dismissed}
-                return [j for j in cached if j["id"] not in dismissed_ids]
+                excluded_ids = {r["job_id"] for r in dismissed} | {r["job_id"] for r in applied}
+                return [j for j in cached if j["id"] not in excluded_ids]
 
         # 2. Vector search
         jobs, cv_row = await _vector_search(conn, req.user_id)

--- a/ai-service/routes/matching.py
+++ b/ai-service/routes/matching.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import os
 
@@ -242,15 +241,13 @@ async def match_jobs(req: MatchRequest):
         if not req.force_refresh:
             cached = await _get_db_cache(conn, req.user_id)
             if cached is not None:
-                dismissed, applied = await asyncio.gather(
-                    conn.fetch(
-                        'SELECT job_id FROM "UserJobInteraction" WHERE user_id = $1',
-                        req.user_id,
-                    ),
-                    conn.fetch(
-                        'SELECT job_id FROM "Application" WHERE user_id = $1',
-                        req.user_id,
-                    ),
+                dismissed = await conn.fetch(
+                    'SELECT job_id FROM "UserJobInteraction" WHERE user_id = $1',
+                    req.user_id,
+                )
+                applied = await conn.fetch(
+                    'SELECT job_id FROM "Application" WHERE user_id = $1',
+                    req.user_id,
                 )
                 excluded_ids = {r["job_id"] for r in dismissed} | {r["job_id"] for r in applied}
                 return [j for j in cached if j["id"] not in excluded_ids]

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@/lib/supabase.server";
 import { db } from "@/lib/db";
 
-export async function GET(_req: NextRequest) {
+export async function GET(req: NextRequest) {
   try {
     const supabase = createServerClient();
     const {
@@ -11,6 +11,13 @@ export async function GET(_req: NextRequest) {
 
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (req.nextUrl.searchParams.get("ids_only") === "true") {
+      const idRows = await db.$queryRaw<{ job_id: string }[]>`
+        SELECT job_id FROM "Application" WHERE user_id = ${user.id}
+      `;
+      return NextResponse.json({ appliedJobIds: idRows.map((r) => r.job_id) });
     }
 
     const rows = await db.$queryRaw<

--- a/app/dashboard/JobCard.tsx
+++ b/app/dashboard/JobCard.tsx
@@ -25,6 +25,7 @@ interface Props {
   job: Job;
   initialSaved?: boolean;
   onDismiss?: (id: string) => void;
+  onApply?: (id: string) => void;
   showScore?: boolean;
   showSource?: boolean;
 }
@@ -63,6 +64,7 @@ export default function JobCard({
   job,
   initialSaved = false,
   onDismiss,
+  onApply,
   showScore = true,
   showSource = false,
 }: Props) {
@@ -210,7 +212,10 @@ export default function JobCard({
           View job
         </a>
         <button
-          onClick={() => router.push(`/dashboard/apply/${job.id}`)}
+          onClick={() => {
+            onApply?.(job.id);
+            router.push(`/dashboard/apply/${job.id}`);
+          }}
           className="text-xs font-medium bg-emerald-600 text-white px-3 py-1.5 rounded-lg hover:bg-emerald-700 transition-colors"
         >
           Apply

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -109,6 +109,7 @@ export default function DashboardPage() {
   // --- My Matches state ---
   const [jobs, setJobs] = useState<Job[]>([]);
   const [savedIds, setSavedIds] = useState<Set<string>>(new Set());
+  const [appliedJobIds, setAppliedJobIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastFetched, setLastFetched] = useState<Date | null>(null);
@@ -191,9 +192,10 @@ export default function DashboardPage() {
     setLoading(true);
     setError(null);
     try {
-      const [matchRes, savedRes] = await Promise.all([
+      const [matchRes, savedRes, appliedRes] = await Promise.all([
         fetch(`/api/match${isRefresh ? "?refresh=true" : ""}`),
         fetch("/api/jobs/saved"),
+        fetch("/api/applications?ids_only=true"),
       ]);
       const matchData = await matchRes.json();
       if (!matchRes.ok) throw new Error(matchData.error ?? "Failed to load jobs");
@@ -202,6 +204,10 @@ export default function DashboardPage() {
       if (savedRes.ok) {
         const savedData = await savedRes.json();
         setSavedIds(new Set((savedData.jobs ?? []).map((j: { id: string }) => j.id)));
+      }
+      if (appliedRes.ok) {
+        const appliedData = await appliedRes.json();
+        setAppliedJobIds(new Set(appliedData.appliedJobIds ?? []));
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load jobs");
@@ -222,12 +228,13 @@ export default function DashboardPage() {
 
   const filteredJobs = useMemo(() => {
     const filtered = jobs
+      .filter((job) => !appliedJobIds.has(job.id))
       .filter((job) => workTypeMatch(job, filters.workTypes))
       .filter((job) => jobTypeMatch(job, filters.jobTypes))
       .filter((job) => dateMatch(job, filters.daysPosted))
       .filter((job) => salaryMatch(job, filters.minSalary));
     return applySort(filtered, filters.sortBy);
-  }, [jobs, filters]);
+  }, [jobs, appliedJobIds, filters]);
 
   const hasBrowseFilter = browseSearch || browseLocation || browseCompany || browseSource;
   const browseFrom = browseTotal === 0 ? 0 : (browsePage - 1) * 20 + 1;
@@ -333,6 +340,7 @@ export default function DashboardPage() {
                     job={job}
                     initialSaved={savedIds.has(job.id)}
                     onDismiss={(id) => setJobs((prev) => prev.filter((j) => j.id !== id))}
+                    onApply={(id) => setJobs((prev) => prev.filter((j) => j.id !== id))}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Bug
Jobs the user clicked Apply on continued showing on the matched jobs dashboard after being added to applications.

## Fix
Three layers of protection:
1. Optimistic UI removal on Apply click (instant)
2. DB matching query excludes jobs in applications table
3. Page load filters applied job IDs from displayed list

## How to test
- Go to dashboard, note a job card
- Click Apply on that job
- Card should disappear immediately from dashboard
- Navigate back to dashboard — job should not reappear
- Click Refresh — job should still not appear
- Check Applications page — job should be there

Closes #44