### PR TITLE
Fix LinkedIn fetcher: Playwright replaces httpx

### DIFF
--- a/ai-service/linkedin_fetcher.py
+++ b/ai-service/linkedin_fetcher.py
@@ -1,8 +1,8 @@
 import asyncio
 import re
 
-import httpx
 from bs4 import BeautifulSoup
+from playwright.async_api import async_playwright
 
 LINKEDIN_SEARCH_TERMS = [
     "software engineer",
@@ -19,17 +19,6 @@ LINKEDIN_SEARCH_TERMS = [
     "cybersecurity engineer",
 ]
 
-HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-    "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/120.0.0.0 Safari/537.36",
-    "Accept": "text/html,application/xhtml+xml,application/xml;"
-    "q=0.9,image/avif,image/webp,*/*;q=0.8",
-    "Accept-Language": "en-US,en;q=0.9",
-    "Accept-Encoding": "gzip, deflate, br",
-    "Referer": "https://www.linkedin.com/",
-}
-
 _ISRAELI_KEYWORDS = [
     "israel",
     "tel aviv",
@@ -42,6 +31,7 @@ _ISRAELI_KEYWORDS = [
     "rehovot",
     "rishon",
     "beer sheva",
+    "tlv",
     "remote - il",
     "תל אביב",
     "ישראל",
@@ -50,121 +40,132 @@ _ISRAELI_KEYWORDS = [
 
 async def fetch_linkedin_jobs_for_term(
     search_term: str,
-    client: httpx.AsyncClient,
+    browser_context,
 ) -> list[dict]:
-    """Fetch LinkedIn jobs for a single search term in Israel."""
+    """Fetch LinkedIn jobs for a single search term in Israel using Playwright."""
     jobs = []
+    page = await browser_context.new_page()
 
-    for start in [0, 25, 50]:
-        url = (
-            "https://www.linkedin.com/jobs/search"
-            f"?keywords={search_term.replace(' ', '%20')}"
-            "&location=Israel"
-            "&f_TPR=r86400"
-            f"&start={start}"
-            "&position=1"
-            "&pageNum=0"
-        )
-
-        try:
-            resp = await client.get(url, timeout=15)
-
-            if resp.status_code == 429:
-                print(f"  LinkedIn rate limited for '{search_term}'")
-                break
-
-            if resp.status_code != 200:
-                print(f"  LinkedIn returned {resp.status_code} for '{search_term}'")
-                break
-
-            soup = BeautifulSoup(resp.text, "html.parser")
-
-            job_cards = soup.find_all(
-                "div",
-                class_=re.compile(r"base-card|job-search-card|jobs-search__results-list"),
+    try:
+        for start in [0, 25, 50]:
+            url = (
+                "https://www.linkedin.com/jobs/search"
+                f"?keywords={search_term.replace(' ', '%20')}"
+                "&location=Israel"
+                "&f_TPR=r86400"
+                f"&start={start}"
             )
 
-            if not job_cards:
+            try:
+                await page.goto(url, wait_until="domcontentloaded", timeout=15000)
+                await page.wait_for_timeout(2000)
+
+                html = await page.content()
+                soup = BeautifulSoup(html, "html.parser")
+
                 job_cards = soup.find_all(
-                    "li",
-                    class_=re.compile(r"jobs-search-results__list-item"),
+                    "div",
+                    class_=re.compile(r"base-card|job-search-card"),
                 )
 
-            if not job_cards:
-                print(f"  No job cards found for '{search_term}' page {start // 25 + 1}")
-                break
-
-            for card in job_cards:
-                try:
-                    title_el = card.find(
-                        ["h3", "h4"],
-                        class_=re.compile(r"title|job-title"),
-                    )
-                    title = title_el.get_text(strip=True) if title_el else ""
-
-                    company_el = card.find(class_=re.compile(r"company|subtitle"))
-                    company = company_el.get_text(strip=True) if company_el else ""
-
-                    location_el = card.find(class_=re.compile(r"location|metadata"))
-                    location = location_el.get_text(strip=True) if location_el else ""
-
-                    link_el = card.find("a", href=True)
-                    job_url = ""
-                    if link_el:
-                        href = link_el["href"]
-                        job_url = href.split("?")[0] if "?" in href else href
-                        if not job_url.startswith("http"):
-                            job_url = "https://www.linkedin.com" + job_url
-
-                    if not title or not job_url:
-                        continue
-
-                    location_lower = location.lower()
-                    if location and not any(kw in location_lower for kw in _ISRAELI_KEYWORDS):
-                        continue
-
-                    jobs.append(
-                        {
-                            "title": title,
-                            "company": company,
-                            "description": "",
-                            "location": location,
-                            "url": job_url,
-                            "source": "linkedin",
-                            "salary_min": None,
-                            "salary_max": None,
-                        }
+                if not job_cards:
+                    job_cards = soup.find_all(
+                        "li",
+                        class_=re.compile(r"jobs-search-results__list-item"),
                     )
 
-                except Exception:
-                    continue
+                if not job_cards:
+                    print(f"  No cards for '{search_term}' page {start // 25 + 1}")
+                    break
 
-            await asyncio.sleep(2)
+                for card in job_cards:
+                    try:
+                        title_el = card.find(
+                            ["h3", "h4"],
+                            class_=re.compile(r"title|job-title"),
+                        )
+                        title = title_el.get_text(strip=True) if title_el else ""
 
-            if len(job_cards) < 10:
+                        company_el = card.find(class_=re.compile(r"company|subtitle"))
+                        company = company_el.get_text(strip=True) if company_el else ""
+
+                        location_el = card.find(class_=re.compile(r"location|metadata"))
+                        location = location_el.get_text(strip=True) if location_el else ""
+
+                        link_el = card.find("a", href=True)
+                        job_url = ""
+                        if link_el:
+                            href = link_el["href"]
+                            job_url = href.split("?")[0] if "?" in href else href
+                            if not job_url.startswith("http"):
+                                job_url = "https://www.linkedin.com" + job_url
+
+                        if not title or not job_url:
+                            continue
+
+                        location_lower = location.lower()
+                        if location and not any(kw in location_lower for kw in _ISRAELI_KEYWORDS):
+                            continue
+
+                        jobs.append(
+                            {
+                                "title": title,
+                                "company": company,
+                                "description": "",
+                                "location": location,
+                                "url": job_url,
+                                "source": "linkedin",
+                                "salary_min": None,
+                                "salary_max": None,
+                            }
+                        )
+
+                    except Exception:
+                        continue
+
+                if len(job_cards) < 10:
+                    break
+
+                await page.wait_for_timeout(2000)
+
+            except Exception as e:
+                print(f"  Page error for '{search_term}': {e}")
                 break
 
-        except Exception as e:
-            print(f"  LinkedIn fetch error for '{search_term}': {e}")
-            break
+    finally:
+        await page.close()
 
     return jobs
 
 
 async def fetch_all_linkedin_jobs() -> list[dict]:
-    """Fetch LinkedIn jobs for all search terms, deduplicated by URL."""
+    """Fetch LinkedIn jobs using a shared Playwright browser across all search terms."""
     try:
         all_jobs: list[dict] = []
         seen_urls: set[str] = set()
 
-        async with httpx.AsyncClient(
-            headers=HEADERS,
-            follow_redirects=True,
-            timeout=15,
-        ) as client:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(
+                headless=True,
+                args=[
+                    "--no-sandbox",
+                    "--disable-setuid-sandbox",
+                    "--disable-blink-features=AutomationControlled",
+                ],
+            )
+
+            context = await browser.new_context(
+                user_agent=(
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+                viewport={"width": 1280, "height": 800},
+            )
+
             for term in LINKEDIN_SEARCH_TERMS:
                 print(f"  LinkedIn: searching '{term}'...")
-                jobs = await fetch_linkedin_jobs_for_term(term, client)
+                jobs = await fetch_linkedin_jobs_for_term(term, context)
 
                 for job in jobs:
                     url = job.get("url", "")
@@ -172,13 +173,15 @@ async def fetch_all_linkedin_jobs() -> list[dict]:
                         seen_urls.add(url)
                         all_jobs.append(job)
 
-                print(f"  LinkedIn '{term}': {len(jobs)} jobs found")
+                print(f"  LinkedIn '{term}': {len(jobs)} jobs")
                 await asyncio.sleep(3)
 
-        print(f"LinkedIn feed total: {len(all_jobs)} unique jobs")
+            await browser.close()
+
+        print(f"LinkedIn total: {len(all_jobs)} unique jobs")
         return all_jobs
 
     except Exception as e:
-        print(f"LinkedIn feed fetcher failed: {e}")
+        print(f"LinkedIn Playwright fetcher failed: {e}")
         print("Continuing without LinkedIn jobs...")
         return []


### PR DESCRIPTION
## Problem
LinkedIn returns HTTP 999 for httpx requests —
TLS fingerprint detected as automation at the edge.

## Fix
Replaced httpx with Playwright (real Chrome browser).
LinkedIn accepts real browser fingerprints and serves
job search results normally.

## How it works
- Single Playwright browser instance shared across
  all 12 search terms (efficient, one launch)
- Each search term gets its own page (tab)
- 2 second delay between pages, 3 seconds between terms
- Falls back gracefully if anything fails

## Test results
**232 unique Israeli LinkedIn jobs** returned across 12 search terms
(vs. 0 with httpx). Sample output:
- Software Engineer | Dream Drifters | Tel Aviv-Yafo, Israel
- Junior Software Engineer | Corephotonics Ltd | Tel Aviv District, Israel
- Full Stack Engineer | Briya | Tel Aviv District, Israel

Closes #48