### PR TITLE
Fix LinkedIn session validation and auto-reconnect on expiry

### DIFF
--- a/ai-service/routes/apply.py
+++ b/ai-service/routes/apply.py
@@ -529,6 +529,15 @@ async def _apply_linkedin(
 ) -> dict:
     await page.wait_for_timeout(2000)
 
+    # Detect auth wall — session expired or cookies not loaded
+    current_url = page.url
+    if any(s in current_url for s in ("/login", "/checkpoint", "authwall", "/signup")):
+        return {
+            "status": "session_expired",
+            "message": "LinkedIn session expired",
+            "action": "reconnect",
+        }
+
     easy_apply = page.locator("button:has-text('Easy Apply')").first
     try:
         await easy_apply.wait_for(state="visible", timeout=5000)

--- a/ai-service/routes/linkedin_auth.py
+++ b/ai-service/routes/linkedin_auth.py
@@ -148,6 +148,49 @@ def _run_login_flow(user_id: str) -> None:
             _login_sessions[user_id] = "error"
 
 
+async def check_linkedin_session_valid(user_id: str) -> bool:
+    """Verify the LinkedIn session is still live by loading /feed headlessly.
+
+    Returns True immediately (no browser) when a login just succeeded in-memory,
+    and False immediately when a login is in progress, to avoid launching a
+    second browser that would conflict with the visible login window.
+    """
+    in_memory = _login_sessions.get(user_id)
+    if in_memory == "success":
+        return True
+    if in_memory == "pending":
+        return False
+    if not _has_saved_session(user_id):
+        return False
+
+    profile_dir = _profile_dir(user_id)
+    try:
+        async with async_playwright() as p:
+            context = await p.chromium.launch_persistent_context(
+                user_data_dir=profile_dir,
+                headless=True,
+                args=["--no-sandbox"],
+            )
+            page = await context.new_page()
+            await page.goto(
+                "https://www.linkedin.com/feed",
+                wait_until="domcontentloaded",
+                timeout=15000,
+            )
+            await page.wait_for_timeout(2000)
+            current_url = page.url
+            is_valid = (
+                "linkedin.com/feed" in current_url
+                or "linkedin.com/in/" in current_url
+                or "linkedin.com/mynetwork" in current_url
+            )
+            await context.close()
+            return is_valid
+    except Exception as e:
+        print(f"[linkedin_auth] session check error for {user_id}: {e}")
+        return False
+
+
 # ── endpoints ─────────────────────────────────────────────────────────────────
 
 @router.post("/linkedin/start-login")
@@ -176,3 +219,10 @@ async def session_status(user_id: str):
         "connected": connected,
         "login_status": in_memory,
     }
+
+
+@router.get("/linkedin/session-valid/{user_id}")
+async def check_session_valid(user_id: str):
+    """Real session validation via headless Playwright — takes 5-10 seconds."""
+    is_valid = await check_linkedin_session_valid(user_id)
+    return {"valid": is_valid, "login_status": _login_sessions.get(user_id)}

--- a/app/api/apply/submit/route.ts
+++ b/app/api/apply/submit/route.ts
@@ -69,6 +69,14 @@ export async function POST(req: NextRequest) {
       WHERE id = ${application_id}
     `;
 
+    if (pythonData.status === "session_expired") {
+      return NextResponse.json({
+        status: "session_expired",
+        message: "Your LinkedIn session expired.",
+        reconnectUrl: "/dashboard/profile",
+      });
+    }
+
     return NextResponse.json({
       status: pythonData.status,
       message: pythonData.message,

--- a/app/api/linkedin/session-status/route.ts
+++ b/app/api/linkedin/session-status/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
 
   try {
     const res = await fetch(
-      `${process.env.PYTHON_SERVICE_URL}/linkedin/session-status/${user.id}`
+      `${process.env.PYTHON_SERVICE_URL}/linkedin/session-valid/${user.id}`
     );
 
     if (!res.ok) {
@@ -21,7 +21,9 @@ export async function GET() {
     }
 
     const data = await res.json();
-    return NextResponse.json(data);
+    // `valid` is the real Playwright check result; `login_status` is kept for
+    // the login-polling flow in the profile page.
+    return NextResponse.json({ connected: data.valid, login_status: data.login_status });
   } catch {
     // Python service down — treat as not connected, don't throw
     return NextResponse.json({ connected: false, login_status: null });

--- a/app/dashboard/apply/[jobId]/page.tsx
+++ b/app/dashboard/apply/[jobId]/page.tsx
@@ -24,7 +24,7 @@ export default function ApplyPage() {
   const [data, setData] = useState<PrepareResult | null>(null);
   const [coverLetter, setCoverLetter] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [submitResult, setSubmitResult] = useState<{ status: string; message: string } | null>(null);
+  const [submitResult, setSubmitResult] = useState<{ status: string; message: string; reconnectUrl?: string } | null>(null);
   const [downloadingCv, setDownloadingCv] = useState(false);
 
   useEffect(() => {
@@ -96,6 +96,8 @@ export default function ApplyPage() {
       } else if (json.status === "manual") {
         showToast("Cover letter saved — finish applying via the link below", "error");
         // Don't auto-redirect — let user see the manual apply button
+      } else if (json.status === "session_expired") {
+        // Don't auto-redirect — show amber reconnect banner
       } else {
         showToast("Something went wrong — check applications", "error");
         setTimeout(() => router.push("/dashboard/applications"), 2000);
@@ -138,6 +140,32 @@ export default function ApplyPage() {
 
   /* ── Submitting / Done ── */
   if (stage === "submitting") {
+    // Session expired — show amber reconnect banner
+    if (submitResult?.status === "session_expired") {
+      return (
+        <div className="max-w-2xl mx-auto mt-12">
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+            <p className="font-medium text-amber-800">LinkedIn session expired</p>
+            <p className="text-amber-700 text-sm mt-1">
+              Your LinkedIn connection needs to be refreshed before you can apply.
+            </p>
+            <a
+              href="/dashboard/profile"
+              className="mt-3 inline-block bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            >
+              Reconnect LinkedIn →
+            </a>
+          </div>
+          <button
+            onClick={() => router.push("/dashboard")}
+            className="mt-4 text-sm text-gray-500 dark:text-gray-400 hover:underline"
+          >
+            ← Back to dashboard
+          </button>
+        </div>
+      );
+    }
+
     // Manual apply — stay on page and show clear CTA
     if (submitResult?.status === "manual") {
       return (

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -42,6 +42,7 @@ function ProfileContent() {
 
   // LinkedIn session state
   const [linkedinConnected, setLinkedinConnected] = useState(false);
+  const [linkedinChecking, setLinkedinChecking] = useState(true);
   const [linkedinConnecting, setLinkedinConnecting] = useState(false);
   const [linkedinModal, setLinkedinModal] = useState(false);
   const [linkedinError, setLinkedinError] = useState("");
@@ -69,11 +70,12 @@ function ProfileContent() {
       .catch(() => {})
       .finally(() => setLoading(false));
 
-    // Check LinkedIn session status on mount
+    // Check LinkedIn session status on mount — real Playwright validation (5-10 s)
     fetch("/api/linkedin/session-status")
       .then((r) => r.json())
-      .then((d) => { if (d.connected) setLinkedinConnected(true); })
-      .catch(() => {});
+      .then((d) => { setLinkedinConnected(!!d.connected); })
+      .catch(() => {})
+      .finally(() => setLinkedinChecking(false));
 
     // Check Google Calendar connection status on mount
     fetch("/api/auth/google/status")
@@ -456,7 +458,9 @@ function ProfileContent() {
             <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">LinkedIn Connection</h2>
             <p className="text-xs text-gray-500 mt-0.5">Required for Easy Apply automation</p>
           </div>
-          {linkedinConnected ? (
+          {linkedinChecking ? (
+            <span className="text-xs text-gray-400 italic">Verifying LinkedIn connection…</span>
+          ) : linkedinConnected ? (
             <div className="flex items-center gap-3 shrink-0">
               <span className="flex items-center gap-1.5 text-xs font-semibold text-green-700 bg-green-100 px-3 py-1.5 rounded-full">
                 <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
@@ -486,7 +490,7 @@ function ProfileContent() {
             </div>
           )}
         </div>
-        {!linkedinConnected && (
+        {!linkedinChecking && !linkedinConnected && (
           <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mt-3">
             Easy Apply won&apos;t work until LinkedIn is connected. Click Connect and log in when the browser opens.
           </p>


### PR DESCRIPTION
Closes #54

## Summary

- **Real session validation**: Added `check_linkedin_session_valid()` in `linkedin_auth.py` — launches headless Playwright, navigates to `/feed`, and confirms the cookie is live. Returns fast (no browser) when a login is currently in progress or just completed, to avoid conflicts with the visible login window.
- **New Python endpoint**: `GET /linkedin/session-valid/{user_id}` — used by the Next.js session-status route instead of the old folder-existence check. Still returns `login_status` for backward-compatible login polling.
- **`session_expired` apply status**: `_apply_linkedin` returns `status: session_expired` (not `failed`) when it hits the auth wall. `submit/route.ts` passes it through to the frontend with a `reconnectUrl`.
- **Amber reconnect banner**: Apply page shows an amber card with a "Reconnect LinkedIn →" link instead of a generic red error when `session_expired` is received.
- **Profile page loading state**: "Verifying LinkedIn connection…" shown while the Playwright check runs on mount; the badge updates to Connected / Not connected once the check completes.

## Test plan

- [ ] Profile page with an expired session shows "Verifying LinkedIn connection…" then "Not connected"
- [ ] Profile page with a valid session shows "Verifying LinkedIn connection…" then "Connected"
- [ ] Attempting Easy Apply with expired session shows amber banner with "Reconnect LinkedIn →" link
- [ ] Reconnect link navigates to `/dashboard/profile`
- [ ] Login flow polling still works (Connected badge appears after successful login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)