### PR TITLE
Fix Easy Apply: experience questions, timeout, and CV tailoring guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ __pycache__/
 # ai-service browser profile
 ai-service/browser_profile
 
+# ai-service runtime artifacts
+ai-service/screenshots/
+
 # vercel
 .vercel
 

--- a/ai-service/routes/apply.py
+++ b/ai-service/routes/apply.py
@@ -325,6 +325,48 @@ async def _ask_claude_for_answer(label: str, user: dict) -> str:
         return ""
 
 
+async def get_years_answer(
+    label_text: str,
+    user_skills: list,
+    years_experience: int,
+) -> str:
+    """Return years-of-experience answer without fabricating skill knowledge."""
+    label_lower = label_text.lower()
+
+    # Generic questions about total career experience
+    generic_patterns = [
+        "years of work experience",
+        "years of professional experience",
+        "total years",
+        "overall experience",
+    ]
+    if any(p in label_lower for p in generic_patterns):
+        return str(min(years_experience, 10))
+
+    # Technology-specific question — extract the tech keyword(s)
+    stop_words = {
+        "years", "experience", "how", "many", "have", "you", "with",
+        "work", "working", "using", "knowledge", "familiarity", "the",
+        "and", "for", "are",
+    }
+    tech_keywords = [
+        word for word in label_lower.split()
+        if len(word) > 2 and word not in stop_words
+    ]
+
+    user_skills_lower = [s.lower() for s in user_skills]
+    has_skill = any(
+        any(kw in skill or skill in kw for skill in user_skills_lower)
+        for kw in tech_keywords
+    )
+
+    if has_skill:
+        return str(min(max(1, years_experience // 2), 5))
+
+    print(f"  No match for '{label_text}' in skills — answering 0")
+    return "0"
+
+
 async def _get_answer_for_field(label: str, user: dict) -> str:
     """Map common LinkedIn field labels to user data, Claude for the rest."""
     label_lower = label.lower()
@@ -345,9 +387,17 @@ async def _get_answer_for_field(label: str, user: dict) -> str:
     if "website" in label_lower or "portfolio" in label_lower:
         return user.get("portfolio_url", "")
 
-    # Questions that benefit from a reasoned answer
+    # Year-of-experience questions — use skill-aware helper, never fabricate
+    if "year" in label_lower:
+        return await get_years_answer(
+            label,
+            user.get("skills", []),
+            int(user.get("years_experience", 0)),
+        )
+
+    # Authorization / sponsorship / salary — Claude answers these
     if any(w in label_lower for w in [
-        "year", "experience", "authorized", "authoris", "require",
+        "experience", "authorized", "authoris", "require",
         "sponsor", "salary", "expect", "notice", "reloc",
     ]):
         return await _ask_claude_for_answer(label, user)

--- a/app/api/apply/prepare/route.ts
+++ b/app/api/apply/prepare/route.ts
@@ -31,14 +31,28 @@ export async function POST(req: NextRequest) {
     }
     const { raw_text } = cvRows[0];
 
-    // Fetch Job
-    const jobRows = await db.$queryRaw<{ title: string; company: string; description: string; url: string }[]>`
-      SELECT title, company, description, url FROM "Job" WHERE id = ${job_id} LIMIT 1
+    // Fetch Job + compute cosine similarity against user's CV embedding
+    const jobRows = await db.$queryRaw<{
+      title: string;
+      company: string;
+      description: string;
+      url: string;
+      match_score: number | null;
+    }[]>`
+      SELECT j.title, j.company, j.description, j.url,
+             CASE WHEN c.embedding IS NOT NULL AND j.embedding IS NOT NULL
+                  THEN CAST(1 - (c.embedding <=> j.embedding) AS FLOAT)
+                  ELSE NULL END AS match_score
+      FROM "Job" j
+      LEFT JOIN "CV" c ON c.user_id = ${user.id}
+      WHERE j.id = ${job_id}
+      LIMIT 1
     `;
     if (!jobRows.length) {
       return NextResponse.json({ error: "Job not found." }, { status: 404 });
     }
     const job = jobRows[0];
+    const matchScore: number | null = job.match_score;
 
     // Call Claude Sonnet to tailor CV
     const prompt =
@@ -56,6 +70,14 @@ export async function POST(req: NextRequest) {
       `- Professional summary: 2 sentences maximum\n` +
       `- Do not add new sections that weren't in the original CV\n` +
       `- Do not expand content — reword and emphasize, do not add\n\n` +
+      `CRITICAL RULES FOR TAILORING:\n` +
+      `- Only emphasize skills and experience the candidate ACTUALLY HAS — never fabricate or exaggerate\n` +
+      `- Do not reframe the candidate's identity — if they are a software engineer, keep them as a software engineer\n` +
+      `- Only highlight genuinely relevant experience for this role\n` +
+      `- If the candidate's background does not match the role requirements at all, write an honest cover letter noting transferable skills rather than misrepresenting experience\n` +
+      `- Never change job titles or invent experience that does not exist in the original CV\n` +
+      `- Maximum change allowed: reorder sections, emphasize relevant existing skills, improve bullet point wording\n` +
+      `- The candidate's core identity and actual experience must remain truthful and accurate\n\n` +
       `CV:\n${raw_text}\n\n` +
       `Job: ${job.title} at ${job.company}\n` +
       `Description: ${job.description.slice(0, 2000)}`;
@@ -118,6 +140,7 @@ export async function POST(req: NextRequest) {
         job_title: job.title,
         company: job.company,
         job_url: job.url,
+        match_score: matchScore,
       });
     }
 
@@ -137,6 +160,7 @@ export async function POST(req: NextRequest) {
       job_title: job.title,
       company: job.company,
       job_url: job.url,
+      match_score: matchScore,
     });
   } catch (err) {
     console.error("[apply/prepare]", err);

--- a/app/api/apply/submit/route.ts
+++ b/app/api/apply/submit/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: NextRequest) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ job_url, application_id, user_id: user.id }),
-        signal: AbortSignal.timeout(120_000),
+        signal: AbortSignal.timeout(300_000), // 5 minutes — Easy Apply modal can be slow
       });
       if (pythonRes.ok) {
         pythonData = await pythonRes.json();
@@ -58,15 +58,26 @@ export async function POST(req: NextRequest) {
         pythonData = { status: "failed", message: `Apply service error (${pythonRes.status})` };
       }
     } catch (e) {
-      console.error("[apply/submit] python call failed:", e);
-      pythonData = { status: "failed", message: e instanceof Error ? e.message : "Could not reach apply service" };
+      const isTimeout =
+        e instanceof Error && (e.name === "TimeoutError" || e.name === "AbortError");
+      if (isTimeout) {
+        pythonData = {
+          status: "timeout",
+          message:
+            "Application may have been submitted — check your LinkedIn to confirm, " +
+            "then update status in Applications page.",
+        };
+      } else {
+        console.error("[apply/submit] python call failed:", e);
+        pythonData = { status: "failed", message: e instanceof Error ? e.message : "Could not reach apply service" };
+      }
     }
 
-    // Update application status
+    // Update application status (timeout → manual so user can confirm manually)
     const finalStatus =
       pythonData.status === "applied"
         ? "applied"
-        : pythonData.status === "manual"
+        : pythonData.status === "manual" || pythonData.status === "timeout"
         ? "manual"
         : "failed";
 

--- a/app/dashboard/apply/[jobId]/page.tsx
+++ b/app/dashboard/apply/[jobId]/page.tsx
@@ -14,6 +14,7 @@ interface PrepareResult {
   job_title: string;
   company: string;
   job_url: string;
+  match_score: number | null;
 }
 
 export default function ApplyPage() {
@@ -85,7 +86,7 @@ export default function ApplyPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ application_id: data.application_id, cover_letter: coverLetter }),
-        signal: AbortSignal.timeout(120_000),
+        signal: AbortSignal.timeout(310_000), // slightly above the 5 min backend timeout
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error ?? "Submission failed");
@@ -96,6 +97,8 @@ export default function ApplyPage() {
       } else if (json.status === "manual") {
         showToast("Cover letter saved — finish applying via the link below", "error");
         // Don't auto-redirect — let user see the manual apply button
+      } else if (json.status === "timeout") {
+        // Don't redirect — amber message shown in render below
       } else {
         // "failed" — show the actual reason from Python (e.g. no LinkedIn session)
         setError(json.message ?? "Something went wrong");
@@ -139,6 +142,37 @@ export default function ApplyPage() {
 
   /* ── Submitting / Done ── */
   if (stage === "submitting") {
+    // Timeout — show amber confirmation prompt
+    if (submitResult?.status === "timeout") {
+      return (
+        <div className="max-w-2xl mx-auto mt-12">
+          <div className="bg-amber-50 border border-amber-300 rounded-xl p-6">
+            <p className="text-lg font-semibold text-amber-900 mb-1">
+              Application may have been submitted successfully
+            </p>
+            <p className="text-sm text-amber-800 mb-4">
+              The submission took longer than expected. Please check your LinkedIn Sent
+              Applications to confirm, then update the status here.
+            </p>
+            <a
+              href="https://www.linkedin.com/my-items/saved-jobs/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block bg-amber-500 hover:bg-amber-600 text-white text-sm font-semibold px-5 py-2.5 rounded-lg transition-colors"
+            >
+              Check LinkedIn Sent Applications →
+            </a>
+            <button
+              onClick={() => router.push("/dashboard/applications")}
+              className="ml-3 text-sm text-amber-700 hover:underline"
+            >
+              View in applications
+            </button>
+          </div>
+        </div>
+      );
+    }
+
     // Manual apply — stay on page and show clear CTA
     if (submitResult?.status === "manual") {
       return (
@@ -213,6 +247,8 @@ export default function ApplyPage() {
   }
 
   /* ── Ready ── */
+  const lowMatch = data?.match_score !== null && data?.match_score !== undefined && data.match_score < 0.45;
+
   return (
     <div className="max-w-2xl mx-auto space-y-6">
       {/* Header */}
@@ -220,6 +256,14 @@ export default function ApplyPage() {
         <h1 className="text-xl font-semibold text-gray-900 dark:text-white">{data!.job_title}</h1>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{data!.company}</p>
       </div>
+
+      {/* Low-match warning */}
+      {lowMatch && (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-800">
+          <span className="font-semibold">Warning:</span> This role may not match your background
+          well. The CV tailoring will be limited to avoid misrepresentation.
+        </div>
+      )}
 
       {/* CV Changes */}
       {data!.cv_changes.length > 0 && (


### PR DESCRIPTION
Closes #60

## Changes

### Fix 1 — Smart years-of-experience answers (`apply.py`)
Added `get_years_answer()` that distinguishes generic career questions from tech-specific ones:
- Generic ("years of work experience") → user's actual total years (capped at 10)
- Tech-specific ("years of Python experience") → checks user's skills list; returns proportional years if matched, **0 if not in profile** — never fabricates
- Replaces the old behaviour of answering every numeric field with the user's total years

### Fix 2 — Timeout handling (`submit/route.ts`, `page.tsx`)
- Backend timeout increased from 2 → 5 minutes (`300_000 ms`)
- Frontend fetch increased to `310_000 ms` to stay above the backend limit
- `TimeoutError`/`AbortError` caught and returned as `{ status: 'timeout' }` with HTTP 200
- DB status set to `manual` on timeout so user can confirm manually
- New amber UI block: "Application may have been submitted — check LinkedIn to confirm" with a link to LinkedIn Sent Applications

### Fix 3 — CV tailoring guardrails (`prepare/route.ts`, `page.tsx`)
- Added explicit rules to Claude prompt: no fabrication, no identity reframing, no invented job titles, max changes are reorder/emphasize/reword
- `prepare` route now computes pgvector cosine similarity and returns `match_score`
- Apply page shows amber warning when `match_score < 0.45`: "This role may not match your background well. The CV tailoring will be limited to avoid misrepresentation."

## Test plan
- [ ] Apply to a job with technology-specific experience fields — verify 0 is entered for unknown techs
- [ ] Apply to a job — let it run >2 min; confirm amber timeout message appears instead of error
- [ ] Apply to a low-match job — confirm amber warning shows on the review screen before submission
- [ ] Apply to a high-match job — confirm no warning shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)