### PR TITLE
Hide Easy Apply browser — run headless (#62)

### DIFF
--- a/ai-service/routes/apply.py
+++ b/ai-service/routes/apply.py
@@ -805,16 +805,14 @@ async def _playwright_apply(
     async with async_playwright() as p:
         ctx = await p.chromium.launch_persistent_context(
             profile_dir,
-            headless=False,
+            headless=True,
             args=[
                 "--no-sandbox",
                 "--disable-setuid-sandbox",
                 "--disable-dev-shm-usage",
                 "--disable-blink-features=AutomationControlled",
                 "--disable-features=IsolateOrigins,site-per-process",
-                "--flag-switches-begin",
-                "--disable-site-isolation-trials",
-                "--flag-switches-end",
+                "--window-size=1280,800",
             ],
             ignore_default_args=["--enable-automation"],
             user_agent=(
@@ -826,9 +824,15 @@ async def _playwright_apply(
         )
         # Remove automation fingerprint signals that LinkedIn uses to detect bots
         await ctx.add_init_script("""
-            Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
-            Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
-            Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
+            Object.defineProperty(navigator, 'webdriver', {
+                get: () => undefined
+            });
+            Object.defineProperty(navigator, 'plugins', {
+                get: () => [1, 2, 3, 4, 5]
+            });
+            Object.defineProperty(navigator, 'languages', {
+                get: () => ['en-US', 'en', 'he']
+            });
             window.chrome = { runtime: {} };
         """)
         page = ctx.pages[0] if ctx.pages else await ctx.new_page()


### PR DESCRIPTION
## Summary
- `headless=False` → `headless=True` in `_playwright_apply` in `ai-service/routes/apply.py`
- Replaced `--flag-switches-begin/--disable-site-isolation-trials/--flag-switches-end` with `--window-size=1280,800` (cleaner stealth arg set)
- Updated `navigator.languages` init script to include `'he'` (Israeli locale)
- `linkedin_auth.py` login flow is **unchanged** — browser stays visible there so users can type credentials

## Test plan
- [ ] Trigger Easy Apply on a LinkedIn job — no browser window should appear on screen
- [ ] App shows loading/processing state throughout
- [ ] Application completes successfully
- [ ] `screenshots/` folder still receives screenshots in headless mode
- [ ] If LinkedIn blocks headless: report the error, do NOT auto-fall back to `headless=False`

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)