### PR TITLE
Add Docker setup for Next.js and FastAPI services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+
+FROM base AS builder
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/ai-service/.dockerignore
+++ b/ai-service/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+*.pyc
+.env
+browser_profile
+screenshots
+*.log

--- a/ai-service/Dockerfile
+++ b/ai-service/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.11-slim
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    chromium \
+    chromium-driver \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    xdg-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+RUN playwright install chromium
+
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  nextjs:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - PYTHON_SERVICE_URL=http://fastapi:8000
+    depends_on:
+      - fastapi
+
+  fastapi:
+    build: ./ai-service
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    volumes:
+      - ./ai-service/companies.csv:/app/companies.csv
+      - ./ai-service/browser_profile:/app/browser_profile
+      - ./ai-service/screenshots:/app/screenshots

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   // distDir default (.next) — kept outside OneDrive via junction symlink
   experimental: {
     serverComponentsExternalPackages: ["pdf-parse", "mammoth"],

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   experimental: {
     serverComponentsExternalPackages: ["pdf-parse"],
   },


### PR DESCRIPTION
## Summary

- **`/Dockerfile`** — multi-stage Next.js build (Node 20 Alpine): deps → build → lean runner with standalone output
- **`/ai-service/Dockerfile`** — Python 3.11-slim with system Chromium + all Playwright deps installed
- **`/docker-compose.yml`** — wires both services; mounts `companies.csv`, `browser_profile/`, and `screenshots/` as volumes so LinkedIn sessions and scraped data persist on the host
- **`.dockerignore`** / **`ai-service/.dockerignore`** — exclude `node_modules`, `.next`, `.env`, `__pycache__`, logs, and browser profile from build context
- **`next.config.js` + `next.config.mjs`** — added `output: 'standalone'` required by the Next.js Dockerfile

## Test plan

- [ ] `docker compose build` completes without errors
- [ ] `docker compose up` starts both services; `curl localhost:3000` and `curl localhost:8000/docs` respond
- [ ] Env vars sourced from `.env` file at project root

🤖 Generated with [Claude Code](https://claude.com/claude-code)