### PR TITLE
Fix Dockerfile: install all deps in builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:20-alpine AS base
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --only=production
 
 FROM base AS builder
+RUN npm ci
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
## Problem
`npm ci --only=production` in the builder stage skipped devDependencies (TypeScript, ESLint, ts-jest, etc.), so `npm run build` would fail with missing modules.

## Fix
Remove `--only=production` from the builder stage. The lean runner image still only copies the compiled `.next/standalone` output, so no dev deps end up in the final image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)