### PR TITLE
Add infinite scroll to My Matches

### DIFF
--- a/ai-service/routes/matching.py
+++ b/ai-service/routes/matching.py
@@ -79,7 +79,7 @@ async def _vector_search(conn, user_id: str) -> tuple[list, dict | None]:
           )
           AND 1 - (j.embedding <=> cv.embedding::vector) > 0.50
         ORDER BY j.embedding <=> cv.embedding::vector
-        LIMIT 50
+        LIMIT 200
         """,
         user_id,
     )

--- a/app/api/match/route.ts
+++ b/app/api/match/route.ts
@@ -12,7 +12,10 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const force_refresh = new URL(req.url).searchParams.get("refresh") === "true";
+    const url = new URL(req.url);
+    const force_refresh = url.searchParams.get("refresh") === "true";
+    const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10));
+    const limit = Math.min(100, Math.max(1, parseInt(url.searchParams.get("limit") ?? "20", 10)));
 
     const pythonRes = await fetch(
       `${process.env.PYTHON_SERVICE_URL}/match-jobs`,
@@ -32,8 +35,17 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    const jobs = await pythonRes.json();
-    return NextResponse.json({ jobs });
+    const allJobs = await pythonRes.json();
+    const start = (page - 1) * limit;
+    const jobs = allJobs.slice(start, start + limit);
+
+    return NextResponse.json({
+      jobs,
+      total: allJobs.length,
+      page,
+      limit,
+      hasMore: start + limit < allJobs.length,
+    });
   } catch (err) {
     console.error("[match]", err);
     const message = err instanceof Error ? err.message : "Internal server error";

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -115,6 +115,11 @@ export default function DashboardPage() {
   const [lastFetched, setLastFetched] = useState<Date | null>(null);
   const [, setTick] = useState(0);
   const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [matchPage, setMatchPage] = useState(1);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const matchObserverRef = useRef<IntersectionObserver | null>(null);
+  const matchBottomRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
 
   // --- Browse state ---
@@ -188,18 +193,38 @@ export default function DashboardPage() {
     return () => clearInterval(id);
   }, []);
 
+  useEffect(() => {
+    matchObserverRef.current = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !loadingMore) {
+          loadMoreJobs();
+        }
+      },
+      { threshold: 0.1 }
+    );
+    if (matchBottomRef.current) {
+      matchObserverRef.current.observe(matchBottomRef.current);
+    }
+    return () => matchObserverRef.current?.disconnect();
+  }, [hasMore, loadingMore, loadMoreJobs]);
+
   const fetchJobs = useCallback(async (isRefresh = false) => {
     setLoading(true);
     setError(null);
+    setMatchPage(1);
+    setHasMore(true);
     try {
+      const params = new URLSearchParams({ page: "1", limit: "20" });
+      if (isRefresh) params.set("refresh", "true");
       const [matchRes, savedRes, appliedRes] = await Promise.all([
-        fetch(`/api/match${isRefresh ? "?refresh=true" : ""}`),
+        fetch(`/api/match?${params}`),
         fetch("/api/jobs/saved"),
         fetch("/api/applications?ids_only=true"),
       ]);
       const matchData = await matchRes.json();
       if (!matchRes.ok) throw new Error(matchData.error ?? "Failed to load jobs");
       setJobs(matchData.jobs);
+      setHasMore(matchData.hasMore);
       setLastFetched(new Date());
       if (savedRes.ok) {
         const savedData = await savedRes.json();
@@ -215,6 +240,24 @@ export default function DashboardPage() {
       setLoading(false);
     }
   }, []);
+
+  const loadMoreJobs = useCallback(async () => {
+    if (!hasMore || loadingMore) return;
+    const nextPage = matchPage + 1;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(`/api/match?page=${nextPage}&limit=20`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setJobs((prev) => [...prev, ...data.jobs]);
+      setMatchPage(nextPage);
+      setHasMore(data.hasMore);
+    } catch (err) {
+      console.error("[loadMore]", err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [hasMore, loadingMore, matchPage]);
 
   useEffect(() => {
     fetch("/api/profile")
@@ -344,6 +387,17 @@ export default function DashboardPage() {
                   />
                 ))}
               </div>
+            )}
+
+            {!loading && !error && (
+              <>
+                <div ref={matchBottomRef} className="h-4" />
+                {loadingMore && (
+                  <div className="flex justify-center py-4">
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-gray-900 dark:border-gray-100" />
+                  </div>
+                )}
+              </>
             )}
           </div>
         </>


### PR DESCRIPTION
Closes #67

## Summary
- **Python**: Increased vector similarity search limit from 50 → 200 (results cached in `match_cache` so extra pages are cheap DB cache hits)
- **Next.js API** (`/api/match`): Added `?page=X&limit=Y` pagination — slices the full cached result set and returns `{ jobs, total, hasMore }`
- **Frontend** (`/app/dashboard/page.tsx`): Added `IntersectionObserver` infinite scroll — loads 20 jobs initially, appends 20 more each time the user reaches the bottom; shows a spinner while loading; stops when `hasMore` is false

## Test plan
- [ ] Open My Matches — first 20 jobs load
- [ ] Scroll to bottom — spinner appears, next 20 jobs append
- [ ] Continue scrolling — keeps loading until all matches are shown
- [ ] Spinner disappears and no more loads once `hasMore` is false
- [ ] Filters still apply correctly to all loaded jobs
- [ ] Refresh button resets to page 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)