### PR TITLE
Fix mobile responsiveness across all pages

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -31,16 +31,17 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
       <div className="mb-6 flex flex-col items-center">
         <Image
           src="/logo.png"
           alt="JobAgent"
-          width={260}
-          height={260}
+          width={200}
+          height={200}
+          className="w-[120px] h-[120px] sm:w-[180px] sm:h-[180px]"
         />
       </div>
-      <div className="w-full max-w-sm bg-white dark:bg-gray-800 p-8 rounded-lg shadow dark:shadow-gray-900">
+      <div className="w-full max-w-sm bg-white dark:bg-gray-800 p-6 sm:p-8 rounded-lg shadow dark:shadow-gray-900">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1 dark:text-gray-300">Email</label>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -48,16 +48,17 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
       <div className="mb-6 flex flex-col items-center">
         <Image
           src="/logo.png"
           alt="JobAgent"
-          width={260}
-          height={260}
+          width={200}
+          height={200}
+          className="w-[120px] h-[120px] sm:w-[180px] sm:h-[180px]"
         />
       </div>
-      <div className="w-full max-w-sm bg-white dark:bg-gray-800 p-8 rounded-lg shadow">
+      <div className="w-full max-w-sm bg-white dark:bg-gray-800 p-6 sm:p-8 rounded-lg shadow">
         <h1 className="text-2xl font-semibold mb-6 dark:text-white">Create account</h1>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>

--- a/app/dashboard/JobCard.tsx
+++ b/app/dashboard/JobCard.tsx
@@ -202,7 +202,7 @@ export default function JobCard({
       )}
 
       {/* Footer */}
-      <div className="mt-4 flex items-center gap-3">
+      <div className="mt-4 flex flex-wrap items-center gap-2">
         <a
           href={job.url}
           target="_blank"

--- a/app/dashboard/NavBarClient.tsx
+++ b/app/dashboard/NavBarClient.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import LogoutButton from "./LogoutButton";
+import { ThemeToggle } from "@/app/components/ThemeToggle";
+
+const NAV_LINKS = [
+  { href: "/dashboard", label: "Jobs" },
+  { href: "/dashboard/applications", label: "Applications" },
+  { href: "/dashboard/saved", label: "Saved" },
+  { href: "/dashboard/my-cv", label: "My CV" },
+  { href: "/dashboard/profile", label: "Profile" },
+];
+
+export default function NavBarClient({ userEmail }: { userEmail: string }) {
+  const [open, setOpen] = useState(false);
+  const username = userEmail.split("@")[0];
+
+  return (
+    <nav className="bg-white dark:bg-gray-800 border-b dark:border-gray-700">
+      <div className="px-4 sm:px-6 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-4 sm:gap-6">
+          <span className="font-semibold text-sm dark:text-white">JobAgent</span>
+          <div className="hidden sm:flex items-center gap-4 text-sm">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="hidden sm:inline text-sm text-gray-500 dark:text-gray-400">
+            {username}
+          </span>
+          <ThemeToggle />
+          <LogoutButton />
+          <button
+            onClick={() => setOpen((v) => !v)}
+            aria-label="Toggle menu"
+            className="sm:hidden p-1.5 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          >
+            {open ? (
+              <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+              </svg>
+            ) : (
+              <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clipRule="evenodd" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <div className="sm:hidden border-t dark:border-gray-700 px-4 py-3 space-y-1">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">{username}</p>
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              onClick={() => setOpen(false)}
+              className="block py-2 text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/app/dashboard/applications/page.tsx
+++ b/app/dashboard/applications/page.tsx
@@ -289,7 +289,7 @@ export default function ApplicationsPage() {
 
       {/* Stats bar */}
       {!loading && !error && (
-        <div className="grid grid-cols-4 gap-3 mb-7">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-7">
           <StatPill label="Applied"      count={counts.applied}      color="border-blue-200 bg-blue-50 text-blue-700" />
           <StatPill label="Interviewing" count={counts.interviewing} color="border-purple-200 bg-purple-50 text-purple-700" />
           <StatPill label="Offers"       count={counts.offer}        color="border-green-200 bg-green-50 text-green-700" />
@@ -321,111 +321,193 @@ export default function ApplicationsPage() {
       )}
 
       {!loading && !error && apps.length > 0 && (
-        <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl overflow-hidden shadow-sm">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide">
-                <th className="text-left px-4 py-3 font-medium">Company</th>
-                <th className="text-left px-4 py-3 font-medium">Role</th>
-                <th className="text-left px-4 py-3 font-medium">Applied</th>
-                <th className="text-left px-4 py-3 font-medium">Status</th>
-                <th className="text-left px-4 py-3 font-medium">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
-              {apps.map((app) => (
-                <tr key={app.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
-                  <td className="px-4 py-3 font-medium text-gray-900 dark:text-white max-w-[160px] truncate">
-                    {app.company}
-                  </td>
-                  <td className="px-4 py-3 text-gray-700 dark:text-gray-300 max-w-[200px] truncate">
-                    {app.job_title}
-                  </td>
-                  <td className="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                    {new Date(app.applied_at).toLocaleDateString("en-GB", {
-                      day: "numeric",
-                      month: "short",
-                      year: "numeric",
-                    })}
-                  </td>
-                  <td className="px-4 py-3">
-                    <select
-                      value={ALLOWED_STATUSES.includes(app.status as AllowedStatus) ? app.status : ""}
-                      disabled={updating === app.id}
-                      onChange={(e) =>
-                        handleStatusChange(app.id, e.target.value as AllowedStatus)
-                      }
-                      className={`text-xs font-semibold px-2.5 py-1 rounded-full border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-400 disabled:opacity-50 ${
-                        STATUS_STYLES[app.status] ?? "bg-gray-100 text-gray-600"
-                      }`}
+        <>
+          {/* Mobile cards */}
+          <div className="sm:hidden space-y-3">
+            {apps.map((app) => (
+              <div
+                key={app.id}
+                className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-4 shadow-sm"
+              >
+                <div className="flex justify-between items-start gap-2">
+                  <div className="min-w-0">
+                    <p className="font-semibold text-gray-900 dark:text-white truncate">{app.job_title}</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{app.company}</p>
+                  </div>
+                  <select
+                    value={ALLOWED_STATUSES.includes(app.status as AllowedStatus) ? app.status : ""}
+                    disabled={updating === app.id}
+                    onChange={(e) => handleStatusChange(app.id, e.target.value as AllowedStatus)}
+                    className={`shrink-0 text-xs font-semibold whitespace-nowrap px-2 py-1 rounded-full border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-400 disabled:opacity-50 ${
+                      STATUS_STYLES[app.status] ?? "bg-gray-100 text-gray-600"
+                    }`}
+                  >
+                    {app.status === "manual" && (
+                      <option value="" disabled className="bg-white text-gray-400 font-normal">Action needed</option>
+                    )}
+                    {app.status === "failed" && (
+                      <option value="" disabled className="bg-white text-gray-400 font-normal">Manual apply needed</option>
+                    )}
+                    {ALLOWED_STATUSES.map((s) => (
+                      <option key={s} value={s} className="bg-white text-gray-800 font-normal">
+                        {s.charAt(0).toUpperCase() + s.slice(1)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
+                  {new Date(app.applied_at).toLocaleDateString("en-GB", {
+                    day: "numeric", month: "short", year: "numeric",
+                  })}
+                </p>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  {app.status === "manual" || app.status === "failed" ? (
+                    <a
+                      href={app.job_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs font-semibold bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 rounded-lg transition-colors"
                     >
-                      {app.status === "manual" && (
-                        <option value="" disabled className="bg-white text-gray-400 font-normal">
-                          Action needed — update after applying
-                        </option>
-                      )}
-                      {app.status === "failed" && (
-                        <option value="" disabled className="bg-white text-gray-400 font-normal">
-                          Manual apply needed
-                        </option>
-                      )}
-                      {ALLOWED_STATUSES.map((s) => (
-                        <option key={s} value={s} className="bg-white text-gray-800 font-normal">
-                          {s.charAt(0).toUpperCase() + s.slice(1)}
-                        </option>
-                      ))}
-                    </select>
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      {app.status === "manual" || app.status === "failed" ? (
-                        <a
-                          href={app.job_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-xs font-semibold bg-orange-500 hover:bg-orange-600 text-white w-28 h-9 px-3 py-2 rounded-lg transition-colors text-center"
-                        >
-                          Apply now →
-                        </a>
-                      ) : (
-                        <a
-                          href={app.job_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-xs font-semibold bg-blue-600 hover:bg-blue-700 text-white w-28 h-9 px-3 py-2 rounded-lg transition-colors text-center"
-                        >
-                          View job ↗
-                        </a>
-                      )}
-                      {app.has_tailored_cv && (
-                        <>
-                          <span className="text-gray-200 dark:text-gray-600 select-none">|</span>
-                          <button
-                            onClick={() => handleDownloadCV(app.id)}
-                            disabled={downloading === app.id}
-                            className="text-emerald-600 hover:text-emerald-700 font-medium disabled:opacity-50 transition-colors whitespace-nowrap"
-                            title="Download tailored CV"
-                          >
-                            {downloading === app.id ? "…" : "CV ↓"}
-                          </button>
-                        </>
-                      )}
-                      <span className="text-gray-200 dark:text-gray-600 select-none">|</span>
-                      <button
-                        onClick={() => handleDelete(app.id)}
-                        disabled={deleting === app.id}
-                        className="text-gray-400 hover:text-red-500 transition-colors disabled:opacity-50 whitespace-nowrap"
-                        title="Delete application"
-                      >
-                        {deleting === app.id ? "…" : "Delete"}
-                      </button>
-                    </div>
-                  </td>
+                      Apply now →
+                    </a>
+                  ) : (
+                    <a
+                      href={app.job_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs font-semibold bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 rounded-lg transition-colors"
+                    >
+                      View job ↗
+                    </a>
+                  )}
+                  {app.has_tailored_cv && (
+                    <button
+                      onClick={() => handleDownloadCV(app.id)}
+                      disabled={downloading === app.id}
+                      className="text-xs font-medium text-emerald-600 hover:text-emerald-700 disabled:opacity-50 transition-colors"
+                    >
+                      {downloading === app.id ? "…" : "CV ↓"}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleDelete(app.id)}
+                    disabled={deleting === app.id}
+                    className="text-xs text-gray-400 hover:text-red-500 transition-colors disabled:opacity-50 ml-auto"
+                  >
+                    {deleting === app.id ? "…" : "Delete"}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop table */}
+          <div className="hidden sm:block bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl overflow-hidden shadow-sm">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wide">
+                  <th className="text-left px-4 py-3 font-medium">Company</th>
+                  <th className="text-left px-4 py-3 font-medium">Role</th>
+                  <th className="text-left px-4 py-3 font-medium">Applied</th>
+                  <th className="text-left px-4 py-3 font-medium">Status</th>
+                  <th className="text-left px-4 py-3 font-medium">Actions</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {apps.map((app) => (
+                  <tr key={app.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                    <td className="px-4 py-3 font-medium text-gray-900 dark:text-white max-w-[160px] truncate">
+                      {app.company}
+                    </td>
+                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300 max-w-[200px] truncate">
+                      {app.job_title}
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      {new Date(app.applied_at).toLocaleDateString("en-GB", {
+                        day: "numeric",
+                        month: "short",
+                        year: "numeric",
+                      })}
+                    </td>
+                    <td className="px-4 py-3">
+                      <select
+                        value={ALLOWED_STATUSES.includes(app.status as AllowedStatus) ? app.status : ""}
+                        disabled={updating === app.id}
+                        onChange={(e) =>
+                          handleStatusChange(app.id, e.target.value as AllowedStatus)
+                        }
+                        className={`text-xs font-semibold whitespace-nowrap px-2.5 py-1 rounded-full border-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-400 disabled:opacity-50 ${
+                          STATUS_STYLES[app.status] ?? "bg-gray-100 text-gray-600"
+                        }`}
+                      >
+                        {app.status === "manual" && (
+                          <option value="" disabled className="bg-white text-gray-400 font-normal">
+                            Action needed — update after applying
+                          </option>
+                        )}
+                        {app.status === "failed" && (
+                          <option value="" disabled className="bg-white text-gray-400 font-normal">
+                            Manual apply needed
+                          </option>
+                        )}
+                        {ALLOWED_STATUSES.map((s) => (
+                          <option key={s} value={s} className="bg-white text-gray-800 font-normal">
+                            {s.charAt(0).toUpperCase() + s.slice(1)}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        {app.status === "manual" || app.status === "failed" ? (
+                          <a
+                            href={app.job_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs font-semibold bg-orange-500 hover:bg-orange-600 text-white w-28 h-9 px-3 py-2 rounded-lg transition-colors text-center"
+                          >
+                            Apply now →
+                          </a>
+                        ) : (
+                          <a
+                            href={app.job_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs font-semibold bg-blue-600 hover:bg-blue-700 text-white w-28 h-9 px-3 py-2 rounded-lg transition-colors text-center"
+                          >
+                            View job ↗
+                          </a>
+                        )}
+                        {app.has_tailored_cv && (
+                          <>
+                            <span className="text-gray-200 dark:text-gray-600 select-none">|</span>
+                            <button
+                              onClick={() => handleDownloadCV(app.id)}
+                              disabled={downloading === app.id}
+                              className="text-emerald-600 hover:text-emerald-700 font-medium disabled:opacity-50 transition-colors whitespace-nowrap"
+                              title="Download tailored CV"
+                            >
+                              {downloading === app.id ? "…" : "CV ↓"}
+                            </button>
+                          </>
+                        )}
+                        <span className="text-gray-200 dark:text-gray-600 select-none">|</span>
+                        <button
+                          onClick={() => handleDelete(app.id)}
+                          disabled={deleting === app.id}
+                          className="text-gray-400 hover:text-red-500 transition-colors disabled:opacity-50 whitespace-nowrap"
+                          title="Delete application"
+                        >
+                          {deleting === app.id ? "…" : "Delete"}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
     </div>
   );

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,12 +1,10 @@
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
-import Link from "next/link";
 import { createServerClient } from "@/lib/supabase.server";
 import { db } from "@/lib/db";
-import LogoutButton from "./LogoutButton";
+import NavBarClient from "./NavBarClient";
 import ChatFab from "./ChatFab";
 import { Toast } from "@/app/components/Toast";
-import { ThemeToggle } from "@/app/components/ThemeToggle";
 
 export default async function DashboardLayout({
   children,
@@ -35,26 +33,8 @@ export default async function DashboardLayout({
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <nav className="bg-white dark:bg-gray-800 border-b dark:border-gray-700 px-6 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-6">
-          <span className="font-semibold text-sm dark:text-white">JobAgent</span>
-          <div className="flex items-center gap-4 text-sm">
-            <Link href="/dashboard" className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors">Jobs</Link>
-            <Link href="/dashboard/applications" className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors">Applications</Link>
-            <Link href="/dashboard/saved" className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors">Saved</Link>
-            <Link href="/dashboard/my-cv" className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors">My CV</Link>
-            <Link href="/dashboard/profile" className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors">Profile</Link>
-          </div>
-        </div>
-        <div className="flex items-center gap-3">
-          <span className="text-sm text-gray-500 dark:text-gray-400">
-            {user.email?.split("@")[0]}
-          </span>
-          <ThemeToggle />
-          <LogoutButton />
-        </div>
-      </nav>
-      <main className="p-6">{children}</main>
+      <NavBarClient userEmail={user.email ?? ""} />
+      <main className="px-4 py-4 sm:px-6 sm:py-6">{children}</main>
       <Toast />
       <ChatFab />
     </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -305,14 +305,14 @@ export default function DashboardPage() {
       {/* ── My Matches ── */}
       {activeTab === "matches" && (
         <>
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-4 gap-2">
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Matched Jobs</h1>
               <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Top matches based on your CV</p>
             </div>
             <div className="flex items-center gap-3">
               {lastFetched && !loading && (
-                <span className="text-xs text-gray-400 dark:text-gray-500">
+                <span className="text-xs text-gray-400 dark:text-gray-500 hidden sm:inline">
                   Last updated: {timeAgo(lastFetched)}
                 </span>
               )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 import { ThemeProvider } from "@/app/components/ThemeProvider";
 import "./globals.css";
@@ -17,6 +17,11 @@ const geistMono = localFont({
 export const metadata: Metadata = {
   title: "JobAgent",
   description: "AI-powered job assistant for the Israeli market",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Closes #69

## Summary
- **Viewport**: Added `Viewport` export in `app/layout.tsx` so the browser correctly sets `width=device-width, initial-scale=1`
- **Navbar**: Extracted `NavBarClient.tsx` (client component) with a hamburger menu — nav links hidden on `< sm`, revealed via toggle
- **Login / Signup**: Added `px-4` outer padding so the form never touches screen edges; logo scales from 120 px on mobile to 180 px on tablet+
- **Dashboard header**: Title and Refresh button stack vertically on mobile (`flex-col sm:flex-row`); "Last updated" text hidden on mobile to save space
- **JobCard footer**: `flex gap-3` → `flex flex-wrap gap-2` so action buttons wrap instead of overflowing on narrow screens
- **Main padding**: Layout `main` changed from `p-6` to `px-4 py-4 sm:px-6 sm:py-6` for tighter mobile padding
- **Applications page**: Stats bar `grid-cols-4` → `grid-cols-2 sm:grid-cols-4` so "Interviewing" pill fits on mobile; table replaced with card layout on mobile (`sm:hidden` cards / `hidden sm:block` table); status `<select>` gets `whitespace-nowrap` to prevent label overflow; card action buttons use `flex-wrap`

## Test plan
- [ ] 375 px (iPhone SE): login/signup form padded and logo smaller; navbar hamburger opens/closes; dashboard header stacks; job card buttons wrap; applications shows cards with no overflow
- [ ] 768 px (iPad): nav shows inline; logo 180 px; header shows "Last updated"; applications shows table
- [ ] 1280 px (desktop): no visual regression — all layouts unchanged from before

🤖 Generated with [Claude Code](https://claude.com/claude-code)