### PR TITLE
Fix mobile: filters floating outside container on dashboard

### DIFF
--- a/app/components/JobFilters.tsx
+++ b/app/components/JobFilters.tsx
@@ -64,7 +64,7 @@ function Chevron() {
   );
 }
 
-const Divider = () => <div className="w-px h-8 bg-gray-200 dark:bg-gray-700 shrink-0 self-end mb-0.5" />;
+const Divider = () => <div className="hidden sm:block w-px h-8 bg-gray-200 dark:bg-gray-700 shrink-0 self-end mb-0.5" />;
 
 export default function JobFilters({ filters, onChange, matchCount, totalCount }: Props) {
   const [open, setOpen] = useState(false);
@@ -73,15 +73,15 @@ export default function JobFilters({ filters, onChange, matchCount, totalCount }
   const bar = (
     <div>
       {/* Filters row */}
-      <div className="flex items-end gap-2">
+      <div className="flex flex-wrap items-end gap-2">
         {/* Sort */}
-        <div>
+        <div className="w-full sm:w-auto">
           <span className={LABEL}>Sort</span>
           <div className="relative">
             <select
               value={filters.sortBy}
               onChange={(e) => onChange({ ...filters, sortBy: e.target.value as SortBy })}
-              className={`${SELECT} min-w-[110px]`}
+              className={`${SELECT} w-full sm:min-w-[110px]`}
             >
               <option value="score">Best match</option>
               <option value="newest">Newest first</option>
@@ -94,7 +94,7 @@ export default function JobFilters({ filters, onChange, matchCount, totalCount }
         <Divider />
 
         {/* Work type */}
-        <div>
+        <div className="w-full sm:w-auto">
           <span className={LABEL}>Work type</span>
           <div className="relative">
             <select
@@ -103,7 +103,7 @@ export default function JobFilters({ filters, onChange, matchCount, totalCount }
                 const v = e.target.value as WorkType | "";
                 onChange({ ...filters, workTypes: v ? [v] : [] });
               }}
-              className={`${SELECT} min-w-[100px]`}
+              className={`${SELECT} w-full sm:min-w-[100px]`}
             >
               <option value="">All types</option>
               <option value="remote">Remote</option>
@@ -117,7 +117,7 @@ export default function JobFilters({ filters, onChange, matchCount, totalCount }
         <Divider />
 
         {/* Job type */}
-        <div>
+        <div className="w-full sm:w-auto">
           <span className={LABEL}>Job type</span>
           <div className="relative">
             <select
@@ -126,7 +126,7 @@ export default function JobFilters({ filters, onChange, matchCount, totalCount }
                 const v = e.target.value as JobType | "";
                 onChange({ ...filters, jobTypes: v ? [v] : [] });
               }}
-              className={`${SELECT} min-w-[100px]`}
+              className={`${SELECT} w-full sm:min-w-[100px]`}
             >
               <option value="">All types</option>
               <option value="full-time">Full-time</option>
@@ -140,13 +140,13 @@ export default function JobFilters({ filters, onChange, matchCount, totalCount }
         <Divider />
 
         {/* Date posted */}
-        <div>
+        <div className="w-full sm:w-auto">
           <span className={LABEL}>Date posted</span>
           <div className="relative">
             <select
               value={filters.daysPosted}
               onChange={(e) => onChange({ ...filters, daysPosted: e.target.value as DaysPosted })}
-              className={`${SELECT} min-w-[100px]`}
+              className={`${SELECT} w-full sm:min-w-[100px]`}
             >
               <option value="any">Any time</option>
               <option value="1">Last 24 hours</option>
@@ -160,19 +160,19 @@ export default function JobFilters({ filters, onChange, matchCount, totalCount }
         <Divider />
 
         {/* Min salary */}
-        <div>
+        <div className="w-full sm:w-auto">
           <span className={LABEL}>Min salary</span>
           <input
             type="number"
             placeholder="₪ Amount"
             value={filters.minSalary}
             onChange={(e) => onChange({ ...filters, minSalary: e.target.value })}
-            className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-2.5 py-1.5 text-xs text-gray-700 dark:text-gray-300 placeholder:text-gray-400 dark:placeholder:text-gray-600 w-[100px] hover:border-gray-400 dark:hover:border-gray-500 focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 focus:outline-none transition-colors"
+            className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-2.5 py-1.5 text-xs text-gray-700 dark:text-gray-300 placeholder:text-gray-400 dark:placeholder:text-gray-600 w-full sm:w-[100px] hover:border-gray-400 dark:hover:border-gray-500 focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 focus:outline-none transition-colors"
           />
         </div>
 
         {/* Spacer + clear filters */}
-        <div className="flex-1 min-w-0" />
+        <div className="hidden sm:block sm:flex-1 sm:min-w-0" />
         {dirty && (
           <button
             type="button"
@@ -197,7 +197,7 @@ export default function JobFilters({ filters, onChange, matchCount, totalCount }
   );
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-5 py-4 mb-6">
+    <div className="w-full overflow-hidden bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm px-4 sm:px-5 py-4 mb-6">
       {/* Mobile toggle */}
       <div className="sm:hidden flex items-center justify-between mb-3">
         <button

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -284,7 +284,7 @@ export default function DashboardPage() {
   const browseTo = browseFrom > 0 ? browseFrom + browseJobs.length - 1 : 0;
 
   return (
-    <div className="max-w-3xl mx-auto">
+    <div className="max-w-3xl mx-auto w-full overflow-hidden">
       {/* Tab bar */}
       <div className="flex gap-1 mb-6 border-b dark:border-gray-700">
         {(["matches", "browse"] as const).map((tab) => (


### PR DESCRIPTION
Closes #71

## Root cause
The filter bar in `JobFilters.tsx` used `flex items-end gap-2` with no wrapping, forcing all five selects into a single horizontal row that overflows the container on mobile.

## Changes
**`app/components/JobFilters.tsx`**
- `flex items-end gap-2` → `flex flex-wrap items-end gap-2` — filters now stack vertically on mobile
- Each filter wrapper: `w-full sm:w-auto` — full-width on mobile, natural width on desktop
- Each select: `w-full sm:min-w-[...]` — stretches to fill its wrapper on mobile
- Min salary input: `w-[100px]` → `w-full sm:w-[100px]`
- Dividers: `hidden sm:block` — hidden when stacked, visible when inline
- Spacer div: `hidden sm:block` — same reason
- Outer container: `w-full overflow-hidden`, padding `px-4 sm:px-5`

**`app/dashboard/page.tsx`**
- Outer wrapper: add `overflow-hidden` as final containment guard

## Test plan
- [ ] 375 px (iPhone SE): expand filters — all selects stack full-width, nothing overflows
- [ ] 768 px (iPad): filters show inline with dividers, identical to before
- [ ] 1280 px (desktop): no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)