### PR TITLE
Add Google SSO with Supabase OAuth (#73)

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -30,6 +30,16 @@ export default function LoginPage() {
     router.push("/dashboard");
   }
 
+  async function handleGoogleSignIn() {
+    const supabase = createBrowserClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback`,
+      },
+    });
+  }
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
       <div className="mb-6 flex flex-col items-center">
@@ -42,6 +52,27 @@ export default function LoginPage() {
         />
       </div>
       <div className="w-full max-w-sm bg-white dark:bg-gray-800 p-6 sm:p-8 rounded-lg shadow dark:shadow-gray-900">
+        <button
+          type="button"
+          onClick={handleGoogleSignIn}
+          className="w-full flex items-center justify-center gap-3 border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors mb-4 text-sm font-medium dark:text-gray-200"
+        >
+          <svg viewBox="0 0 24 24" className="w-5 h-5">
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+          </svg>
+          Continue with Google
+        </button>
+        <div className="relative my-4">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-gray-300 dark:border-gray-600" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400">or</span>
+          </div>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1 dark:text-gray-300">Email</label>
@@ -82,3 +113,4 @@ export default function LoginPage() {
     </div>
   );
 }
+

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -34,6 +34,16 @@ export default function SignupPage() {
     setDone(true);
   }
 
+  async function handleGoogleSignIn() {
+    const supabase = createBrowserClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback`,
+      },
+    });
+  }
+
   if (done) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
@@ -60,6 +70,27 @@ export default function SignupPage() {
       </div>
       <div className="w-full max-w-sm bg-white dark:bg-gray-800 p-6 sm:p-8 rounded-lg shadow">
         <h1 className="text-2xl font-semibold mb-6 dark:text-white">Create account</h1>
+        <button
+          type="button"
+          onClick={handleGoogleSignIn}
+          className="w-full flex items-center justify-center gap-3 border border-gray-300 dark:border-gray-600 rounded-lg px-4 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors mb-4 text-sm font-medium dark:text-gray-200"
+        >
+          <svg viewBox="0 0 24 24" className="w-5 h-5">
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+          </svg>
+          Continue with Google
+        </button>
+        <div className="relative my-4">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-gray-300 dark:border-gray-600" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400">or</span>
+          </div>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-1 dark:text-gray-300">Name</label>

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,17 @@
+import { createServerClient } from "@/lib/supabase.server";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+
+  if (code) {
+    const supabase = createServerClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}/dashboard`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/login?error=auth`);
+}


### PR DESCRIPTION
## Summary
- Adds "Continue with Google" button (with Google's official colors) to login and signup pages
- Adds an "or" divider between the Google button and email/password form
- Creates `/app/auth/callback/route.ts` to handle the OAuth code exchange and redirect to `/dashboard`
- Full dark mode support on all new UI elements

## Manual step required before merging
Go to **Supabase Dashboard → Authentication → Providers → Google** and:
1. Enable the Google provider
2. Enter `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
3. Add `NEXT_PUBLIC_APP_URL` to your `.env` (e.g. `http://localhost:3000` for dev, your prod URL for prod)
4. In Google Cloud Console, add `<your-supabase-project>.supabase.co/auth/v1/callback` as an authorized redirect URI

## Test plan
- [ ] Enable Google provider in Supabase (see above)
- [ ] Click "Continue with Google" on login page → redirected to Google consent → lands on `/dashboard`
- [ ] Click "Continue with Google" on signup page → same flow works for new users
- [ ] Bad/missing OAuth code → redirected to `/login?error=auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)