### PR TITLE
Fix multiple UI issues: dark mode, mobile layout, Google button, work mode multi-select (#75)

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -65,6 +65,7 @@ export default function LoginPage() {
           borderRadius: 8,
           padding: "10px 16px",
           background: "white",
+          color: "#111",
           fontSize: 14,
           fontWeight: 500,
           cursor: "pointer",

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -92,6 +92,7 @@ export default function SignupPage() {
           borderRadius: 8,
           padding: "10px 16px",
           background: "white",
+          color: "#111",
           fontSize: 14,
           fontWeight: 500,
           cursor: "pointer",

--- a/app/api/preferences/route.ts
+++ b/app/api/preferences/route.ts
@@ -25,21 +25,24 @@ export async function PATCH(req: NextRequest) {
 
     // Update job preferences
     if (body.job_preferences !== undefined) {
-      const { titles, locations, remote_ok, min_salary } = body.job_preferences as {
+      const { titles, locations, remote_ok, work_modes, min_salary } = body.job_preferences as {
         titles: string[];
         locations: string[];
         remote_ok: boolean;
+        work_modes?: string[];
         min_salary: number | null;
       };
+      const workModes: string[] = Array.isArray(work_modes) ? work_modes : [];
 
       await db.$executeRaw`
-        INSERT INTO "JobPreference" (id, user_id, titles, locations, remote_ok, min_salary, updated_at)
+        INSERT INTO "JobPreference" (id, user_id, titles, locations, remote_ok, work_modes, min_salary, updated_at)
         VALUES (gen_random_uuid(), ${user.id}, ${titles}::text[], ${locations}::text[],
-                ${remote_ok}, ${min_salary}, now())
+                ${remote_ok}, ${workModes}::text[], ${min_salary}, now())
         ON CONFLICT (user_id) DO UPDATE
           SET titles     = EXCLUDED.titles,
               locations  = EXCLUDED.locations,
               remote_ok  = EXCLUDED.remote_ok,
+              work_modes = EXCLUDED.work_modes,
               min_salary = EXCLUDED.min_salary,
               updated_at = now()
       `;

--- a/app/api/profile/preferences/route.ts
+++ b/app/api/profile/preferences/route.ts
@@ -17,16 +17,18 @@ export async function POST(req: NextRequest) {
     const titles: string[] = Array.isArray(body.titles) ? body.titles : [];
     const locations: string[] = Array.isArray(body.locations) ? body.locations : (body.location ? [body.location] : []);
     const remoteOk: boolean = body.remote_ok === true;
+    const workModes: string[] = Array.isArray(body.work_modes) ? body.work_modes : [];
     const minSalary: number | null = body.min_salary ? parseInt(body.min_salary) : null;
 
     await db.$executeRaw`
-      INSERT INTO "JobPreference" (id, user_id, titles, locations, remote_ok, min_salary, updated_at)
+      INSERT INTO "JobPreference" (id, user_id, titles, locations, remote_ok, work_modes, min_salary, updated_at)
       VALUES (gen_random_uuid(), ${user.id}, ${titles}::text[], ${locations}::text[],
-              ${remoteOk}, ${minSalary}, now())
+              ${remoteOk}, ${workModes}::text[], ${minSalary}, now())
       ON CONFLICT (user_id) DO UPDATE
         SET titles     = EXCLUDED.titles,
             locations  = EXCLUDED.locations,
             remote_ok  = EXCLUDED.remote_ok,
+            work_modes = EXCLUDED.work_modes,
             min_salary = EXCLUDED.min_salary,
             updated_at = now()
     `;

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -18,8 +18,8 @@ export async function GET(_req: NextRequest) {
         SELECT id, clean_summary, skills_json, updated_at, raw_text
         FROM "CV" WHERE user_id = ${user.id} LIMIT 1
       `,
-      db.$queryRaw<{ titles: string[]; locations: string[]; remote_ok: boolean; min_salary: number | null }[]>`
-        SELECT titles, locations, remote_ok, min_salary
+      db.$queryRaw<{ titles: string[]; locations: string[]; remote_ok: boolean; work_modes: string[]; min_salary: number | null }[]>`
+        SELECT titles, locations, remote_ok, work_modes, min_salary
         FROM "JobPreference" WHERE user_id = ${user.id} LIMIT 1
       `,
       db.user.findUnique({

--- a/app/dashboard/onboarding/page.tsx
+++ b/app/dashboard/onboarding/page.tsx
@@ -4,8 +4,6 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
-type WorkMode = "remote" | "hybrid" | "onsite";
-
 interface ExistingCV {
   clean_summary: string;
   skills_json: { skills?: string[]; years_experience?: number } | null;
@@ -18,6 +16,7 @@ interface Profile {
     titles?: string[];
     locations?: string[];
     remote_ok?: boolean;
+    work_modes?: string[];
     min_salary?: number;
   };
   google_connected?: boolean;
@@ -38,9 +37,15 @@ export default function OnboardingPage() {
   const [titleInput, setTitleInput] = useState("");
   const [titles, setTitles] = useState<string[]>([]);
   const [location, setLocation] = useState("");
-  const [workMode, setWorkMode] = useState<WorkMode>("hybrid");
+  const [workModes, setWorkModes] = useState<string[]>(["Hybrid"]);
   const [minSalary, setMinSalary] = useState("");
   const [skipSalary, setSkipSalary] = useState(false);
+
+  function toggleWorkMode(mode: string) {
+    setWorkModes((prev) =>
+      prev.includes(mode) ? prev.filter((m) => m !== mode) : [...prev, mode]
+    );
+  }
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -59,7 +64,11 @@ export default function OnboardingPage() {
           const prefs = d.preferences;
           if (prefs.titles?.length) setTitles(prefs.titles);
           if (prefs.locations?.[0]) setLocation(prefs.locations[0]);
-          if (prefs.remote_ok) setWorkMode("remote");
+          if (prefs.work_modes?.length) {
+            setWorkModes(prefs.work_modes);
+          } else {
+            setWorkModes(prefs.remote_ok ? ["Remote"] : ["Hybrid"]);
+          }
           if (prefs.min_salary) setMinSalary(String(prefs.min_salary));
           else setSkipSalary(true);
         }
@@ -91,7 +100,8 @@ export default function OnboardingPage() {
         form.append("cv", file);
         form.append("titles", JSON.stringify(titles));
         form.append("location", location);
-        form.append("remote_ok", String(workMode === "remote"));
+        form.append("remote_ok", String(workModes.includes("Remote")));
+        form.append("work_modes", JSON.stringify(workModes));
         form.append("min_salary", skipSalary ? "" : minSalary);
 
         const res = await fetch("/api/cv/upload", { method: "POST", body: form });
@@ -105,7 +115,8 @@ export default function OnboardingPage() {
           body: JSON.stringify({
             titles,
             locations: location ? [location] : [],
-            remote_ok: workMode === "remote",
+            remote_ok: workModes.includes("Remote"),
+            work_modes: workModes,
             min_salary: skipSalary ? null : (minSalary ? parseInt(minSalary) : null),
           }),
         });
@@ -113,7 +124,7 @@ export default function OnboardingPage() {
         if (!res.ok) throw new Error(data.error ?? "Update failed");
       }
 
-      router.push(file ? "/dashboard/my-cv" : "/dashboard");
+      router.push("/dashboard");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
@@ -292,7 +303,7 @@ export default function OnboardingPage() {
               <button
                 type="button"
                 onClick={addTitle}
-                className="px-3 py-2 bg-gray-100 rounded text-sm hover:bg-gray-200"
+                className="bg-gray-100 dark:bg-gray-600 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-500 rounded-md px-3 py-1.5 text-sm hover:bg-gray-200 dark:hover:bg-gray-500"
               >
                 Add
               </button>
@@ -327,18 +338,20 @@ export default function OnboardingPage() {
           {/* Work mode */}
           <div>
             <label className="block text-sm font-medium mb-2">Work mode</label>
-            <div className="flex gap-4">
-              {(["remote", "hybrid", "onsite"] as WorkMode[]).map((m) => (
-                <label key={m} className="flex items-center gap-1.5 text-sm">
-                  <input
-                    type="radio"
-                    name="workMode"
-                    value={m}
-                    checked={workMode === m}
-                    onChange={() => setWorkMode(m)}
-                  />
-                  {m.charAt(0).toUpperCase() + m.slice(1)}
-                </label>
+            <div className="flex flex-wrap gap-2">
+              {["Remote", "Hybrid", "On-site"].map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => toggleWorkMode(mode)}
+                  className={`px-4 py-2 rounded-full border text-sm transition-colors ${
+                    workModes.includes(mode)
+                      ? "bg-[#1a2e5e] text-white border-[#1a2e5e]"
+                      : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600"
+                  }`}
+                >
+                  {mode}
+                </button>
               ))}
             </div>
           </div>

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -4,11 +4,9 @@ import { useEffect, useRef, useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { showToast } from "@/app/components/Toast";
 
-type WorkMode = "remote" | "hybrid" | "onsite";
-
 interface Profile {
   cv: { clean_summary: string | null; skills_json: string | null; updated_at: string } | null;
-  preferences: { titles: string[]; locations: string[]; remote_ok: boolean; min_salary: number | null } | null;
+  preferences: { titles: string[]; locations: string[]; remote_ok: boolean; work_modes: string[]; min_salary: number | null } | null;
 }
 
 function ProfileContent() {
@@ -24,9 +22,15 @@ function ProfileContent() {
   const [titleInput, setTitleInput] = useState("");
   const [titles, setTitles] = useState<string[]>([]);
   const [location, setLocation] = useState("");
-  const [workMode, setWorkMode] = useState<WorkMode>("hybrid");
+  const [workModes, setWorkModes] = useState<string[]>(["Hybrid"]);
   const [minSalary, setMinSalary] = useState("");
   const [skipSalary, setSkipSalary] = useState(false);
+
+  function toggleWorkMode(mode: string) {
+    setWorkModes((prev) =>
+      prev.includes(mode) ? prev.filter((m) => m !== mode) : [...prev, mode]
+    );
+  }
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
@@ -60,7 +64,11 @@ function ProfileContent() {
         if (data.preferences) {
           setTitles(data.preferences.titles ?? []);
           setLocation(data.preferences.locations?.[0] ?? "");
-          setWorkMode(data.preferences.remote_ok ? "remote" : "hybrid");
+          if (data.preferences.work_modes?.length) {
+            setWorkModes(data.preferences.work_modes);
+          } else {
+            setWorkModes(data.preferences.remote_ok ? ["Remote"] : ["Hybrid"]);
+          }
           if (data.preferences.min_salary) {
             setMinSalary(String(data.preferences.min_salary));
           } else {
@@ -210,21 +218,29 @@ function ProfileContent() {
     setError("");
     setSaving(true);
 
-    const form = new FormData();
-    // If no new file, send a placeholder so the API knows to skip CV re-processing
-    if (file) form.append("cv", file);
-    else {
-      // Send an empty cv blob so the upload endpoint skips PDF parsing
-      form.append("cv_skip", "true");
+    let res: Response;
+    if (file) {
+      const form = new FormData();
+      form.append("cv", file);
+      form.append("titles", JSON.stringify(titles));
+      form.append("location", location);
+      form.append("remote_ok", String(workModes.includes("Remote")));
+      form.append("work_modes", JSON.stringify(workModes));
+      form.append("min_salary", skipSalary ? "" : minSalary);
+      res = await fetch("/api/cv/upload", { method: "POST", body: form });
+    } else {
+      res = await fetch("/api/profile/preferences", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          titles,
+          locations: location ? [location] : [],
+          remote_ok: workModes.includes("Remote"),
+          work_modes: workModes,
+          min_salary: skipSalary ? null : (minSalary ? parseInt(minSalary) : null),
+        }),
+      });
     }
-    form.append("titles", JSON.stringify(titles));
-    form.append("location", location);
-    form.append("remote_ok", String(workMode === "remote"));
-    form.append("min_salary", skipSalary ? "" : minSalary);
-
-    // If we have a new CV file, use the full upload endpoint
-    const endpoint = file ? "/api/cv/upload" : "/api/profile/preferences";
-    const res = await fetch(endpoint, { method: "POST", body: form });
     const data = await res.json().catch(() => ({}));
 
     if (!res.ok) {
@@ -380,7 +396,7 @@ function ProfileContent() {
         </div>
 
         {/* Job preferences */}
-        <div className="bg-white border rounded-xl p-5 space-y-4">
+        <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5 space-y-4">
           <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Job Preferences</h2>
 
           <div>
@@ -394,7 +410,7 @@ function ProfileContent() {
                 placeholder="e.g. Frontend Developer"
                 className="flex-1 border dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-gray-400"
               />
-              <button type="button" onClick={addTitle} className="px-3 py-2 bg-gray-100 rounded text-sm hover:bg-gray-200">Add</button>
+              <button type="button" onClick={addTitle} className="px-3 py-1.5 bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-500 rounded-md text-sm hover:bg-gray-200 dark:hover:bg-gray-600">Add</button>
             </div>
             {titles.length > 0 && (
               <div className="flex flex-wrap gap-2 mt-2">
@@ -421,12 +437,20 @@ function ProfileContent() {
 
           <div>
             <label className="block text-sm font-medium mb-2">Work mode</label>
-            <div className="flex gap-4">
-              {(["remote", "hybrid", "onsite"] as WorkMode[]).map((m) => (
-                <label key={m} className="flex items-center gap-1.5 text-sm">
-                  <input type="radio" name="workMode" value={m} checked={workMode === m} onChange={() => setWorkMode(m)} />
-                  {m.charAt(0).toUpperCase() + m.slice(1)}
-                </label>
+            <div className="flex flex-wrap gap-2">
+              {["Remote", "Hybrid", "On-site"].map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => toggleWorkMode(mode)}
+                  className={`px-4 py-2 rounded-full border text-sm transition-colors ${
+                    workModes.includes(mode)
+                      ? "bg-[#1a2e5e] text-white border-[#1a2e5e]"
+                      : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600"
+                  }`}
+                >
+                  {mode}
+                </button>
               ))}
             </div>
           </div>
@@ -477,15 +501,15 @@ function ProfileContent() {
 
       {/* LinkedIn Connection */}
       <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5">
-        <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
           <div>
             <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">LinkedIn Connection</h2>
             <p className="text-xs text-gray-500 mt-0.5">Required for Easy Apply automation</p>
           </div>
           {linkedinChecking ? (
-            <span className="text-xs text-gray-400 italic shrink-0">Verifying LinkedIn connection…</span>
+            <span className="text-xs text-gray-400 italic self-end sm:self-auto">Verifying LinkedIn connection…</span>
           ) : linkedinConnected ? (
-            <div className="flex items-center gap-3 shrink-0">
+            <div className="flex items-center gap-3 self-end sm:self-auto">
               <span className="flex items-center gap-1.5 text-xs font-semibold text-green-700 bg-green-100 px-3 py-1.5 rounded-full">
                 <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
                 Connected
@@ -499,7 +523,7 @@ function ProfileContent() {
               </button>
             </div>
           ) : (
-            <div className="flex items-center gap-3 shrink-0">
+            <div className="flex items-center gap-3 self-end sm:self-auto">
               <span className="flex items-center gap-1.5 text-xs font-semibold text-amber-700 bg-amber-100 px-3 py-1.5 rounded-full">
                 <span className="w-1.5 h-1.5 rounded-full bg-amber-500 inline-block" />
                 Not connected
@@ -523,13 +547,13 @@ function ProfileContent() {
 
       {/* Google Calendar Connection */}
       <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5">
-        <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
           <div>
             <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Google Calendar</h2>
             <p className="text-xs text-gray-500 mt-0.5">For scheduling interviews from the chat assistant</p>
           </div>
           {googleConnected ? (
-            <div className="flex items-center gap-3 shrink-0">
+            <div className="flex items-center gap-3 self-end sm:self-auto">
               <span className="flex items-center gap-1.5 text-xs font-semibold text-green-700 bg-green-100 px-3 py-1.5 rounded-full">
                 <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
                 Connected
@@ -543,7 +567,7 @@ function ProfileContent() {
               </button>
             </div>
           ) : (
-            <div className="flex items-center gap-3 shrink-0">
+            <div className="flex items-center gap-3 self-end sm:self-auto">
               <span className="flex items-center gap-1.5 text-xs font-semibold text-gray-600 bg-gray-100 px-3 py-1.5 rounded-full">
                 Not connected
               </span>
@@ -571,12 +595,12 @@ function ProfileContent() {
       </div>
 
       {/* Notifications */}
-      <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5">
-        <h2 className="text-sm font-semibold text-gray-700 mb-3">Notifications</h2>
+      <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5 pb-24 sm:pb-5">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Notifications</h2>
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm font-medium text-gray-900">Daily match emails</p>
-            <p className="text-xs text-gray-500 mt-0.5">Get an email when new jobs are found</p>
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Daily match emails</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Get an email when new jobs are found</p>
           </div>
           <button
             onClick={() => handleEmailToggle(!emailNotifications)}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model JobPreference {
   titles     String[]
   locations  String[]
   remote_ok  Boolean  @default(false)
+  work_modes String[] @default([])
   min_salary Int?
   updated_at DateTime @updatedAt
 


### PR DESCRIPTION
Closes #75

## Summary

- **FIX 1** — Job preferences container: `bg-white` → `bg-white dark:bg-gray-800`, Add button gets dark mode classes
- **FIX 2** — Notifications section: all text now has `dark:text-gray-100/300/400` variants
- **FIX 3/4** — LinkedIn + Google Calendar containers: `flex-col` on mobile → `flex-row` on desktop; status/button element uses `self-end sm:self-auto` so it aligns right on mobile and inline on desktop
- **FIX 5** — Notifications card: `pb-24 sm:pb-5` keeps the toggle button above the chat bubble on mobile
- **FIX 6** — Login + Signup Google button: explicit `color: "#111"` so text is never inherited white
- **FIX 7** — Onboarding Add title button: `dark:bg-gray-600 dark:text-white dark:border-gray-500`
- **FIX 8** — Work mode: replaced single radio (remote/hybrid/onsite) with multi-select toggle pills (Remote / Hybrid / On-site) in both profile and onboarding pages; `work_modes String[] @default([])` added to `JobPreference` schema; all three API routes (`/api/profile/preferences`, `/api/preferences`, `/api/profile`) updated; backward-compatible load (falls back to `remote_ok` when `work_modes` is empty)
- **FIX 9** — Onboarding: always `router.push("/dashboard")` on completion

## Test plan

- [ ] Profile page dark mode: job preferences card has dark background, Add button visible
- [ ] Profile page dark mode: Notifications text visible
- [ ] Profile page mobile: LinkedIn + Google Calendar containers stack vertically; buttons align right
- [ ] Profile page mobile: scroll to bottom — notification toggle is above chat bubble
- [ ] Login + Signup: "Continue with Google" text is dark on white button
- [ ] Onboarding dark mode: Add button visible
- [ ] Work mode pills: can select multiple, selected pills turn navy, deselect works
- [ ] Completing onboarding redirects to `/dashboard`
- [ ] **Run migration**: `npx prisma migrate dev --name add_work_modes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)