### PR TITLE
Fix LinkedIn connect: cookie-based auth instead of headed browser

### DIFF
--- a/ai-service/routes/apply.py
+++ b/ai-service/routes/apply.py
@@ -791,8 +791,10 @@ async def _playwright_apply(
     profile_dir: str,
 ) -> dict:
     if is_linkedin:
+        cookies_json_path = os.path.join(profile_dir, "cookies.json")
         has_cookies = (
-            os.path.exists(os.path.join(profile_dir, "Default", "Network", "Cookies"))
+            os.path.exists(cookies_json_path)
+            or os.path.exists(os.path.join(profile_dir, "Default", "Network", "Cookies"))
             or os.path.exists(os.path.join(profile_dir, "Default", "Cookies"))
             or os.path.exists(os.path.join(profile_dir, "Cookies"))
         )
@@ -822,6 +824,17 @@ async def _playwright_apply(
             ),
             viewport={"width": 1280, "height": 800},
         )
+
+        # Load cookie-based LinkedIn session if available
+        _cookies_json = os.path.join(profile_dir, "cookies.json")
+        if os.path.exists(_cookies_json):
+            import json as _json_mod
+            try:
+                with open(_cookies_json) as _f:
+                    _saved = _json_mod.load(_f)
+                await ctx.add_cookies(_saved)
+            except Exception as _exc:
+                print(f"[apply] Failed to load cookies.json: {_exc}")
         # Remove automation fingerprint signals that LinkedIn uses to detect bots
         await ctx.add_init_script("""
             Object.defineProperty(navigator, 'webdriver', {

--- a/ai-service/routes/linkedin_auth.py
+++ b/ai-service/routes/linkedin_auth.py
@@ -1,8 +1,12 @@
 import asyncio
+import json
 import os
 import threading
+from datetime import datetime
 from urllib.parse import urlparse
 
+import asyncpg
+import httpx
 from fastapi import APIRouter
 from playwright.async_api import async_playwright
 
@@ -18,19 +22,20 @@ def _profile_dir(user_id: str) -> str:
 
 
 def _has_saved_session(user_id: str) -> bool:
-    """Return True only when a non-empty Cookies file exists in the profile."""
+    """Return True when a usable LinkedIn session exists in the profile directory."""
     base = _profile_dir(user_id)
     if not os.path.isdir(base):
         return False
-    # Chromium 120+ writes cookies to Default/Network/Cookies; older builds use
-    # Default/Cookies or Cookies at the root.  Check all three, require >1 KB so
-    # a freshly-created but empty file doesn't produce a false positive.
-    cookie_paths = [
+    # Cookie-based auth (new approach): cookies.json written by save_linkedin_cookie
+    cookie_json = os.path.join(base, "cookies.json")
+    if os.path.exists(cookie_json) and os.path.getsize(cookie_json) > 10:
+        return True
+    # Chromium browser-profile cookies (legacy approach)
+    for cookie_path in [
         os.path.join(base, "Default", "Network", "Cookies"),
         os.path.join(base, "Default", "Cookies"),
         os.path.join(base, "Cookies"),
-    ]
-    for cookie_path in cookie_paths:
+    ]:
         if os.path.exists(cookie_path) and os.path.getsize(cookie_path) > 1024:
             return True
     return False
@@ -204,16 +209,58 @@ async def login_poll(user_id: str):
     return {"connected": connected, "login_status": status}
 
 
-def _run_session_check(user_id: str) -> dict:
-    """Run the headless Playwright session check in its own event loop.
+_LINKEDIN_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+}
 
-    Playwright uses asyncio.create_subprocess_exec internally which raises
-    NotImplementedError when called directly inside uvicorn's Windows event
-    loop.  Running it in a thread with asyncio.run() gives it a fresh loop
-    that supports subprocesses on all platforms.
+
+def _run_session_check(user_id: str) -> dict:
+    """Validate the LinkedIn session.
+
+    Uses httpx if cookies.json exists (cookie-based auth, new approach).
+    Falls back to headless Playwright for legacy browser-profile sessions.
     """
     async def _check() -> dict:
         profile_dir = _profile_dir(user_id)
+        cookie_json_path = os.path.join(profile_dir, "cookies.json")
+
+        # Fast path — httpx validation for cookie-based sessions
+        if os.path.exists(cookie_json_path):
+            try:
+                with open(cookie_json_path) as _f:
+                    saved_cookies = json.load(_f)
+                li_at = next((c["value"] for c in saved_cookies if c["name"] == "li_at"), None)
+                if li_at:
+                    headers = {**_LINKEDIN_HEADERS, "Cookie": f"li_at={li_at}"}
+                    async with httpx.AsyncClient() as client:
+                        resp = await client.get(
+                            "https://www.linkedin.com/feed/",
+                            headers=headers,
+                            follow_redirects=False,
+                            timeout=10.0,
+                        )
+                    location = str(resp.headers.get("location", ""))
+                    is_valid = not (
+                        ("login" in location or "authwall" in location)
+                        and resp.status_code in (301, 302, 303, 307, 308)
+                    )
+                    print(f"[session-status] {user_id}: {'valid' if is_valid else 'expired'} (httpx)")
+                    if not is_valid:
+                        for _f in [cookie_json_path, os.path.join(profile_dir, "linkedin_cookie.json")]:
+                            try:
+                                os.remove(_f)
+                            except Exception:
+                                pass
+                        return {"connected": False, "login_status": "expired"}
+                    return {"connected": True, "login_status": _login_sessions.get(user_id)}
+            except Exception as exc:
+                print(f"[session-status] httpx check error: {exc}")
+
+        # Fallback — headless Playwright for legacy browser-profile sessions
         async with async_playwright() as p:
             context = await p.chromium.launch_persistent_context(
                 user_data_dir=profile_dir,
@@ -239,7 +286,6 @@ def _run_session_check(user_id: str) -> dict:
                     if os.path.exists(cookie_file):
                         try:
                             os.remove(cookie_file)
-                            print(f"[session-status] cleared expired cookies: {cookie_file}")
                         except Exception:
                             pass
                 return {"connected": False, "login_status": "expired"}
@@ -251,6 +297,75 @@ def _run_session_check(user_id: str) -> dict:
     except Exception as e:
         print(f"[session-status] check failed for {user_id}: {e}")
         return {"connected": False, "login_status": "check_failed"}
+
+
+@router.post("/linkedin/save-cookie")
+async def save_linkedin_cookie(data: dict):
+    """Validate and persist a LinkedIn li_at session cookie for a user."""
+    user_id: str = data.get("user_id", "")
+    cookie_value: str = (data.get("cookie") or "").strip()
+
+    if not user_id or not cookie_value:
+        return {"success": False, "error": "user_id and cookie are required"}
+
+    # Validate cookie — LinkedIn redirects to /login when the session is invalid
+    headers = {**_LINKEDIN_HEADERS, "Cookie": f"li_at={cookie_value}"}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://www.linkedin.com/feed/",
+                headers=headers,
+                follow_redirects=False,
+                timeout=10.0,
+            )
+        location = str(resp.headers.get("location", ""))
+        if resp.status_code in (301, 302, 303, 307, 308) and (
+            "login" in location or "authwall" in location
+        ):
+            return {"success": False, "error": "Invalid cookie — please try again"}
+    except Exception as exc:
+        return {"success": False, "error": f"Could not validate cookie: {exc}"}
+
+    # Persist cookie files
+    profile_dir = _profile_dir(user_id)
+    os.makedirs(profile_dir, exist_ok=True)
+
+    with open(os.path.join(profile_dir, "linkedin_cookie.json"), "w") as _f:
+        json.dump({"li_at": cookie_value, "saved_at": datetime.now().isoformat()}, _f)
+
+    playwright_cookies = [{
+        "name": "li_at",
+        "value": cookie_value,
+        "domain": ".linkedin.com",
+        "path": "/",
+        "httpOnly": True,
+        "secure": True,
+        "sameSite": "None",
+    }]
+    with open(os.path.join(profile_dir, "cookies.json"), "w") as _f:
+        json.dump(playwright_cookies, _f)
+
+    # Mark session as connected in memory
+    _login_sessions[user_id] = "success"
+
+    # Persist the cookie path in the DB (non-fatal if it fails)
+    database_url = os.getenv("DATABASE_URL")
+    if database_url:
+        try:
+            conn = await asyncpg.connect(database_url)
+            try:
+                await conn.execute(
+                    'UPDATE "User" SET linkedin_session_path = $1 WHERE id = $2',
+                    os.path.join(profile_dir, "cookies.json"),
+                    user_id,
+                )
+            finally:
+                await conn.close()
+        except Exception as exc:
+            print(f"[save-cookie] DB update failed (non-fatal): {exc}")
+
+    print(f"[save-cookie] {user_id}: cookie saved successfully")
+    return {"success": True, "message": "LinkedIn connected successfully"}
 
 
 @router.get("/linkedin/session-status/{user_id}")

--- a/app/api/linkedin/start-session/route.ts
+++ b/app/api/linkedin/start-session/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@/lib/supabase.server";
 
-export async function POST() {
+export async function POST(req: NextRequest) {
   const supabase = createServerClient();
   const {
     data: { user },
@@ -11,22 +11,31 @@ export async function POST() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const body = await req.json();
+  const cookie: string = (body.cookie ?? "").trim();
+  if (!cookie) {
+    return NextResponse.json({ error: "cookie is required" }, { status: 400 });
+  }
+
   try {
     const res = await fetch(
-      `${process.env.PYTHON_SERVICE_URL}/linkedin/start-login`,
+      `${process.env.PYTHON_SERVICE_URL}/linkedin/save-cookie`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ user_id: user.id }),
+        body: JSON.stringify({ user_id: user.id, cookie }),
       }
     );
 
-    if (!res.ok) {
-      return NextResponse.json({ error: "Python service error" }, { status: 502 });
+    const data = await res.json();
+    if (!res.ok || !data.success) {
+      return NextResponse.json(
+        { error: data.error ?? "Failed to save cookie" },
+        { status: 502 }
+      );
     }
 
-    const data = await res.json();
-    return NextResponse.json(data);
+    return NextResponse.json({ success: true });
   } catch (err) {
     console.error("[linkedin/start-session]", err);
     return NextResponse.json({ error: "Service unavailable" }, { status: 503 });

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, Suspense } from "react";
+import { useEffect, useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { showToast } from "@/app/components/Toast";
 
@@ -50,8 +50,8 @@ function ProfileContent() {
   const [linkedinChecking, setLinkedinChecking] = useState(true);
   const [linkedinConnecting, setLinkedinConnecting] = useState(false);
   const [linkedinModal, setLinkedinModal] = useState(false);
+  const [linkedinCookie, setLinkedinCookie] = useState("");
   const [linkedinError, setLinkedinError] = useState("");
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     fetch("/api/profile")
@@ -104,9 +104,6 @@ function ProfileContent() {
     }
   }, []);
 
-  // Cleanup polling on unmount
-  useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
-
   // Auto-unsubscribe when ?unsubscribe=true
   useEffect(() => {
     if (searchParams.get("unsubscribe") === "true" && !loading) {
@@ -116,56 +113,36 @@ function ProfileContent() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading]);
 
-  async function handleConnectLinkedin() {
+  function handleConnectLinkedin() {
     setLinkedinError("");
-    setLinkedinConnecting(true);
+    setLinkedinCookie("");
     setLinkedinModal(true);
+  }
 
-    try {
-      const res = await fetch("/api/linkedin/start-session", { method: "POST" });
-      const data = await res.json();
-      if (!res.ok || data.error) throw new Error(data.error ?? "Failed to start session");
-    } catch (err) {
-      setLinkedinError(err instanceof Error ? err.message : "Failed to start");
-      setLinkedinConnecting(false);
+  async function handleSubmitLinkedinCookie() {
+    if (!linkedinCookie.trim()) {
+      setLinkedinError("Please paste your li_at cookie value.");
       return;
     }
-
-    // Poll every 3 s for up to 2 minutes.
-    // Uses /login-poll (fast in-memory check) — NOT /session-status — so the
-    // heavy Playwright validation never runs while the login browser is open.
-    let elapsed = 0;
-    pollRef.current = setInterval(async () => {
-      elapsed += 3;
-      try {
-        const res = await fetch("/api/linkedin/login-poll");
-        const data = await res.json();
-        if (data.connected) {
-          clearInterval(pollRef.current!);
-          setLinkedinConnected(true);
-          setLinkedinConnecting(false);
-          setLinkedinModal(false);
-          showToast("LinkedIn connected!", "success");
-          return;
-        }
-        if (data.login_status === "timeout" || data.login_status === "error") {
-          clearInterval(pollRef.current!);
-          setLinkedinConnecting(false);
-          setLinkedinError(
-            data.login_status === "timeout"
-              ? "Timed out — you have 2 minutes to log in. Try again."
-              : "Something went wrong. Try again."
-          );
-          return;
-        }
-      } catch { /* ignore transient errors */ }
-
-      if (elapsed >= 120) {
-        clearInterval(pollRef.current!);
-        setLinkedinConnecting(false);
-        setLinkedinError("Timed out after 2 minutes. Try again.");
-      }
-    }, 3000);
+    setLinkedinError("");
+    setLinkedinConnecting(true);
+    try {
+      const res = await fetch("/api/linkedin/start-session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cookie: linkedinCookie.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error ?? "Failed to connect");
+      setLinkedinConnected(true);
+      setLinkedinModal(false);
+      setLinkedinCookie("");
+      showToast("LinkedIn connected!", "success");
+    } catch (err) {
+      setLinkedinError(err instanceof Error ? err.message : "Something went wrong. Try again.");
+    } finally {
+      setLinkedinConnecting(false);
+    }
   }
 
   async function handleEmailToggle(value: boolean) {
@@ -197,10 +174,10 @@ function ProfileContent() {
   }
 
   function cancelLinkedinConnect() {
-    if (pollRef.current) clearInterval(pollRef.current);
     setLinkedinConnecting(false);
     setLinkedinModal(false);
     setLinkedinError("");
+    setLinkedinCookie("");
   }
 
   function addTitle() {
@@ -281,49 +258,55 @@ function ProfileContent() {
 
   return (
     <div className="max-w-lg mx-auto space-y-6">
-      {/* LinkedIn instruction modal */}
+      {/* LinkedIn cookie modal */}
       {linkedinModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6">
-            <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-2">Connect LinkedIn</h2>
-            {linkedinConnecting && !linkedinError ? (
-              <>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                  A browser window is opening on this machine. Log in to LinkedIn normally —
-                  the window will close automatically once you&apos;re signed in.
-                </p>
-                <div className="flex items-center gap-3 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 mb-3">
-                  <span className="inline-flex gap-0.5">
-                    <span className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-bounce [animation-delay:0ms]" />
-                    <span className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-bounce [animation-delay:150ms]" />
-                    <span className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-bounce [animation-delay:300ms]" />
-                  </span>
-                  <span className="text-sm text-blue-700">Waiting for login… (up to 2 minutes)</span>
-                </div>
-                <button
-                  onClick={async () => {
-                    if (pollRef.current) clearInterval(pollRef.current);
-                    await fetch("/api/linkedin/force-connected", { method: "POST" });
-                    setLinkedinConnected(true);
-                    setLinkedinConnecting(false);
-                    setLinkedinModal(false);
-                    showToast("LinkedIn connected!", "success");
-                  }}
-                  className="text-sm text-blue-600 hover:underline mb-5 block"
-                >
-                  I&apos;ve logged in — mark as connected
-                </button>
-              </>
-            ) : null}
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md p-6">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-4">Connect LinkedIn</h2>
+
+            <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 mb-4">
+              <p className="text-sm font-medium text-blue-900 dark:text-blue-100 mb-2">
+                How to get your LinkedIn cookie:
+              </p>
+              <ol className="text-sm text-blue-800 dark:text-blue-200 space-y-1 list-decimal list-inside">
+                <li>Open <strong>LinkedIn.com</strong> and make sure you&apos;re logged in</li>
+                <li>Press <strong>F12</strong> to open Developer Tools</li>
+                <li>Click the <strong>Application</strong> tab (Chrome) or <strong>Storage</strong> tab (Firefox)</li>
+                <li>Expand <strong>Cookies</strong> → click <strong>https://www.linkedin.com</strong></li>
+                <li>Find the cookie named <strong>li_at</strong></li>
+                <li>Copy the entire <strong>Value</strong> column</li>
+                <li>Paste it in the field below</li>
+              </ol>
+            </div>
+
+            <textarea
+              value={linkedinCookie}
+              onChange={(e) => setLinkedinCookie(e.target.value)}
+              placeholder="Paste your li_at cookie value here…"
+              className="w-full h-24 border dark:border-gray-600 rounded-lg p-3 text-sm font-mono resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 mb-3"
+              disabled={linkedinConnecting}
+            />
+
             {linkedinError && (
-              <p className="text-sm text-red-600 mb-4">{linkedinError}</p>
+              <p className="text-sm text-red-600 dark:text-red-400 mb-3">{linkedinError}</p>
             )}
-            <button
-              onClick={cancelLinkedinConnect}
-              className="w-full border dark:border-gray-600 rounded-lg py-2 text-sm dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
-            >
-              {linkedinConnecting ? "Cancel" : "Close"}
-            </button>
+
+            <div className="flex gap-3">
+              <button
+                onClick={cancelLinkedinConnect}
+                disabled={linkedinConnecting}
+                className="flex-1 border dark:border-gray-600 rounded-lg py-2 text-sm dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSubmitLinkedinCookie}
+                disabled={linkedinConnecting || !linkedinCookie.trim()}
+                className="flex-1 bg-blue-600 hover:bg-blue-700 text-white rounded-lg py-2 text-sm font-semibold disabled:opacity-50"
+              >
+                {linkedinConnecting ? "Connecting…" : "Connect LinkedIn"}
+              </button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Closes #77

## What broke
`linkedin_auth.py` used `headless=False` to open a Chromium window so the user could log in. On EC2/Linux there is no display — Chromium crashes, the in-memory status flips to `error`, and the user sees "Something went wrong. Try again."

Even with Xvfb installed the browser would open invisibly on the server, so the user could never interact with it.

## Fix
Replace the headed-browser flow with a cookie-paste modal.

### Changes

**`app/dashboard/profile/page.tsx`**
- New modal: step-by-step instructions for finding the `li_at` cookie + textarea to paste it
- Removed polling loop and `pollRef` — replaced with a single `POST /api/linkedin/start-session`

**`app/api/linkedin/start-session/route.ts`**
- Now accepts `{ cookie }` in the request body and forwards to FastAPI `/linkedin/save-cookie`

**`ai-service/routes/linkedin_auth.py`**
- New `POST /linkedin/save-cookie`: validates the cookie via httpx (no browser), writes `cookies.json` and `linkedin_cookie.json` to `browser_profile/{user_id}/`, sets in-memory session status to `success`, updates `linkedin_session_path` in DB
- `_has_saved_session()`: now also checks for `cookies.json`
- `_run_session_check()`: fast httpx path when `cookies.json` exists — no Playwright needed for session checks

**`ai-service/routes/apply.py`**
- `has_cookies` check: includes `cookies.json`
- After context creation: loads `cookies.json` via `ctx.add_cookies()` so the apply flow is authenticated

## Test plan
- [ ] Deploy to EC2, click "Connect LinkedIn" — modal appears with instructions
- [ ] Paste a valid `li_at` cookie → "LinkedIn connected!" toast, badge turns green
- [ ] Paste an invalid cookie → "Invalid cookie — please try again" error in modal
- [ ] After connecting, reload the profile page → badge stays green (httpx session check)
- [ ] Attempt a LinkedIn Easy Apply job → cookies loaded, no "session not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)