### PR TITLE
Add Easy Apply default answers: profile fields + extension form filler

### DIFF
--- a/app/api/apply/check-pending/route.ts
+++ b/app/api/apply/check-pending/route.ts
@@ -34,12 +34,11 @@ export async function GET(request: NextRequest) {
   if (!jobIdParam && !jobUrl) return NextResponse.json({ pending: false });
 
   // Prefer explicit jobId param; fall back to extracting from the jobUrl.
-  // extractJobId handles Hebrew slugs where /view/ is followed by text, not digits.
   const linkedinJobId = jobIdParam ?? (jobUrl ? extractJobId(jobUrl) : null);
 
   console.log(`[check-pending] userId=${userId} jobIdParam=${jobIdParam} jobUrl=${jobUrl} → linkedinJobId=${linkedinJobId}`);
 
-  // --- DEBUG: show all pending_extension apps for this user so we can compare ---
+  // --- DEBUG: show all pending_extension apps for this user ---
   const allPending = await db.$queryRaw<{ id: string; job_id: string; status: string; job_url: string }[]>`
     SELECT a.id, a.job_id, a.status, j.url AS job_url
     FROM "Application" a
@@ -52,9 +51,6 @@ export async function GET(request: NextRequest) {
   let rows: { id: string; job_url: string }[];
 
   if (linkedinJobId) {
-    // Search for the job ID anywhere in the stored URL — handles both:
-    //   stored: /jobs/view/4417922448/
-    //   stored: /jobs/view/hebrew-text-4417922448/   (Hebrew slug from JobSpy)
     rows = await db.$queryRaw<{ id: string; job_url: string }[]>`
       SELECT a.id, j.url AS job_url
       FROM "Application" a
@@ -80,9 +76,31 @@ export async function GET(request: NextRequest) {
 
   if (!rows.length) return NextResponse.json({ pending: false });
 
-  const cvRows = await db.$queryRaw<{ skills_json: unknown }[]>`
-    SELECT skills_json FROM "CV" WHERE user_id = ${userId} LIMIT 1
-  `;
+  // Fetch profile defaults and CV skills in parallel
+  const [profile, cvRows] = await Promise.all([
+    db.user.findUnique({
+      where: { id: userId },
+      select: {
+        first_name: true,
+        last_name: true,
+        phone: true,
+        city: true,
+        linkedin_url: true,
+        github_url: true,
+        portfolio_url: true,
+        expected_salary: true,
+        notice_period: true,
+        years_of_experience: true,
+        highest_education: true,
+        work_authorized: true,
+        requires_sponsorship: true,
+        willing_to_relocate: true,
+      },
+    }),
+    db.$queryRaw<{ skills_json: unknown }[]>`
+      SELECT skills_json FROM "CV" WHERE user_id = ${userId} LIMIT 1
+    `,
+  ]);
 
   const skills: string[] = (() => {
     const raw = cvRows[0]?.skills_json;
@@ -95,12 +113,26 @@ export async function GET(request: NextRequest) {
     application: {
       id: rows[0].id,
       jobUrl: rows[0].job_url,
+      // Personal
+      first_name: profile?.first_name ?? null,
+      last_name: profile?.last_name ?? null,
+      phone: profile?.phone ?? null,
+      city: profile?.city ?? null,
+      // URLs
+      linkedin_url: profile?.linkedin_url ?? null,
+      github_url: profile?.github_url ?? null,
+      portfolio_url: profile?.portfolio_url ?? null,
+      // Work details
+      expected_salary: profile?.expected_salary ?? null,
+      notice_period: profile?.notice_period ?? "30",
+      years_of_experience: profile?.years_of_experience ?? "2",
+      highest_education: profile?.highest_education ?? "Bachelor's Degree",
+      // Boolean defaults
+      work_authorized: profile?.work_authorized ?? true,
+      requires_sponsorship: profile?.requires_sponsorship ?? false,
+      willing_to_relocate: profile?.willing_to_relocate ?? false,
+      // CV skills
       skills,
-      phone: null,
-      city: null,
-      linkedin_url: null,
-      expected_salary: null,
-      notice_period: null,
     },
   });
 }

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -20,12 +20,28 @@ export async function GET(_req: NextRequest) {
       `,
       db.user.findUnique({
         where: { id: user.id },
-        select: { google_connected: true, email_notifications: true },
+        select: {
+          google_connected: true,
+          email_notifications: true,
+          first_name: true,
+          last_name: true,
+          phone: true,
+          city: true,
+          linkedin_url: true,
+          github_url: true,
+          portfolio_url: true,
+          expected_salary: true,
+          notice_period: true,
+          years_of_experience: true,
+          highest_education: true,
+          work_authorized: true,
+          requires_sponsorship: true,
+          willing_to_relocate: true,
+        },
       }),
     ]);
 
-    // Run preferences query separately so a missing column (e.g. pending migration)
-    // never causes the entire route to 500 and hide the CV from the client.
+    // Run preferences query separately so a missing column never causes 500
     let prefRows: { titles: string[]; locations: string[]; remote_ok: boolean; work_modes: string[]; min_salary: number | null }[] = [];
     try {
       prefRows = await db.$queryRaw`
@@ -33,7 +49,6 @@ export async function GET(_req: NextRequest) {
         FROM "JobPreference" WHERE user_id = ${user.id} LIMIT 1
       `;
     } catch {
-      // Fallback: try without work_modes in case migration hasn't run yet
       try {
         const rows = await db.$queryRaw<{ titles: string[]; locations: string[]; remote_ok: boolean; min_salary: number | null }[]>`
           SELECT titles, locations, remote_ok, min_salary
@@ -50,9 +65,72 @@ export async function GET(_req: NextRequest) {
       preferences: prefRows[0] ?? null,
       google_connected: dbUser?.google_connected ?? false,
       email_notifications: dbUser?.email_notifications ?? true,
+      // Easy Apply defaults
+      first_name: dbUser?.first_name ?? null,
+      last_name: dbUser?.last_name ?? null,
+      phone: dbUser?.phone ?? null,
+      city: dbUser?.city ?? null,
+      linkedin_url: dbUser?.linkedin_url ?? null,
+      github_url: dbUser?.github_url ?? null,
+      portfolio_url: dbUser?.portfolio_url ?? null,
+      expected_salary: dbUser?.expected_salary ?? null,
+      notice_period: dbUser?.notice_period ?? "30",
+      years_of_experience: dbUser?.years_of_experience ?? "2",
+      highest_education: dbUser?.highest_education ?? "Bachelor's Degree",
+      work_authorized: dbUser?.work_authorized ?? true,
+      requires_sponsorship: dbUser?.requires_sponsorship ?? false,
+      willing_to_relocate: dbUser?.willing_to_relocate ?? false,
     });
   } catch (err) {
     console.error("[profile GET]", err);
+    const message = err instanceof Error ? err.message : "Internal server error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  try {
+    const supabase = createServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const {
+      first_name, last_name, phone, city,
+      linkedin_url, github_url, portfolio_url,
+      expected_salary, notice_period, years_of_experience,
+      highest_education, work_authorized, requires_sponsorship,
+      willing_to_relocate,
+    } = body;
+
+    await db.user.update({
+      where: { id: user.id },
+      data: {
+        first_name,
+        last_name,
+        phone,
+        city,
+        linkedin_url,
+        github_url,
+        portfolio_url,
+        expected_salary,
+        notice_period,
+        years_of_experience,
+        highest_education,
+        work_authorized,
+        requires_sponsorship,
+        willing_to_relocate,
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[profile PATCH]", err);
     const message = err instanceof Error ? err.message : "Internal server error";
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -9,6 +9,23 @@ interface Profile {
   preferences: { titles: string[]; locations: string[]; remote_ok: boolean; work_modes: string[]; min_salary: number | null } | null;
 }
 
+interface EasyApplyDefaults {
+  first_name: string;
+  last_name: string;
+  phone: string;
+  city: string;
+  linkedin_url: string;
+  github_url: string;
+  portfolio_url: string;
+  expected_salary: string;
+  notice_period: string;
+  years_of_experience: string;
+  highest_education: string;
+  work_authorized: boolean;
+  requires_sponsorship: boolean;
+  willing_to_relocate: boolean;
+}
+
 function ProfileContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -35,6 +52,16 @@ function ProfileContent() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
+  // Easy Apply defaults
+  const [defaults, setDefaults] = useState<EasyApplyDefaults>({
+    first_name: "", last_name: "", phone: "", city: "",
+    linkedin_url: "", github_url: "", portfolio_url: "",
+    expected_salary: "", notice_period: "30", years_of_experience: "2",
+    highest_education: "Bachelor's Degree",
+    work_authorized: true, requires_sponsorship: false, willing_to_relocate: false,
+  });
+  const [savingDefaults, setSavingDefaults] = useState(false);
+
   // Notifications
   const [emailNotifications, setEmailNotifications] = useState(true);
   const [savingEmail, setSavingEmail] = useState(false);
@@ -56,11 +83,27 @@ function ProfileContent() {
   useEffect(() => {
     fetch("/api/profile")
       .then((r) => r.json())
-      .then((data: Profile & { email_notifications?: boolean }) => {
+      .then((data: Profile & { email_notifications?: boolean } & EasyApplyDefaults) => {
         setProfile(data);
         if (typeof data.email_notifications === "boolean") {
           setEmailNotifications(data.email_notifications);
         }
+        setDefaults({
+          first_name: data.first_name ?? "",
+          last_name: data.last_name ?? "",
+          phone: data.phone ?? "",
+          city: data.city ?? "",
+          linkedin_url: data.linkedin_url ?? "",
+          github_url: data.github_url ?? "",
+          portfolio_url: data.portfolio_url ?? "",
+          expected_salary: data.expected_salary ?? "",
+          notice_period: data.notice_period ?? "30",
+          years_of_experience: data.years_of_experience ?? "2",
+          highest_education: data.highest_education ?? "Bachelor's Degree",
+          work_authorized: data.work_authorized ?? true,
+          requires_sponsorship: data.requires_sponsorship ?? false,
+          willing_to_relocate: data.willing_to_relocate ?? false,
+        });
         if (data.preferences) {
           setTitles(data.preferences.titles ?? []);
           setLocation(data.preferences.locations?.[0] ?? "");
@@ -142,6 +185,23 @@ function ProfileContent() {
       setLinkedinError(err instanceof Error ? err.message : "Something went wrong. Try again.");
     } finally {
       setLinkedinConnecting(false);
+    }
+  }
+
+  async function handleSaveDefaults() {
+    setSavingDefaults(true);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(defaults),
+      });
+      if (!res.ok) throw new Error("Failed to save");
+      showToast("Auto Apply defaults saved", "success");
+    } catch {
+      showToast("Failed to save defaults", "error");
+    } finally {
+      setSavingDefaults(false);
     }
   }
 
@@ -653,6 +713,150 @@ function ProfileContent() {
             )}
           </div>
         )}
+      </div>
+
+      {/* Auto Apply Defaults */}
+      <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5 space-y-4">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Auto Apply Defaults</h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            Used automatically when applying to jobs via the Chrome extension
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {[
+            { label: "First name", key: "first_name", placeholder: "Hasan" },
+            { label: "Last name", key: "last_name", placeholder: "Masalha" },
+            { label: "Phone", key: "phone", placeholder: "+972-50-000-0000" },
+            { label: "City", key: "city", placeholder: "Tel Aviv" },
+          ].map(({ label, key, placeholder }) => (
+            <div key={key}>
+              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">{label}</label>
+              <input
+                type="text"
+                value={defaults[key as keyof EasyApplyDefaults] as string}
+                onChange={e => setDefaults({ ...defaults, [key]: e.target.value })}
+                placeholder={placeholder}
+                className="w-full border dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#1a2e5e]"
+              />
+            </div>
+          ))}
+
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">LinkedIn Profile URL</label>
+            <input
+              type="url"
+              value={defaults.linkedin_url}
+              onChange={e => setDefaults({ ...defaults, linkedin_url: e.target.value })}
+              placeholder="https://linkedin.com/in/yourname"
+              className="w-full border dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#1a2e5e]"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">GitHub URL</label>
+            <input
+              type="url"
+              value={defaults.github_url}
+              onChange={e => setDefaults({ ...defaults, github_url: e.target.value })}
+              placeholder="https://github.com/yourname"
+              className="w-full border dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#1a2e5e]"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Portfolio / Website</label>
+            <input
+              type="url"
+              value={defaults.portfolio_url}
+              onChange={e => setDefaults({ ...defaults, portfolio_url: e.target.value })}
+              placeholder="https://yourwebsite.com"
+              className="w-full border dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#1a2e5e]"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Expected Salary (monthly, NIS)</label>
+            <input
+              type="text"
+              value={defaults.expected_salary}
+              onChange={e => setDefaults({ ...defaults, expected_salary: e.target.value })}
+              placeholder="20000"
+              className="w-full border dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#1a2e5e]"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Notice period (days)</label>
+            <input
+              type="text"
+              value={defaults.notice_period}
+              onChange={e => setDefaults({ ...defaults, notice_period: e.target.value })}
+              placeholder="30"
+              className="w-full border dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#1a2e5e]"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Years of experience</label>
+            <input
+              type="text"
+              value={defaults.years_of_experience}
+              onChange={e => setDefaults({ ...defaults, years_of_experience: e.target.value })}
+              placeholder="2"
+              className="w-full border dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#1a2e5e]"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Highest education</label>
+            <select
+              value={defaults.highest_education}
+              onChange={e => setDefaults({ ...defaults, highest_education: e.target.value })}
+              className="w-full border dark:border-gray-600 rounded px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-[#1a2e5e]"
+            >
+              {["High School", "Associate's Degree", "Bachelor's Degree", "Master's Degree", "PhD", "Bootcamp / Self-taught"].map(o => (
+                <option key={o}>{o}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Boolean defaults */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 pt-1">
+          {([
+            { label: "Authorized to work in Israel?", key: "work_authorized", yesFirst: true },
+            { label: "Requires visa sponsorship?", key: "requires_sponsorship", yesFirst: false },
+            { label: "Willing to relocate?", key: "willing_to_relocate", yesFirst: true },
+          ] as { label: string; key: keyof EasyApplyDefaults; yesFirst: boolean }[]).map(({ label, key, yesFirst }) => (
+            <div key={key}>
+              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">{label}</label>
+              <div className="flex gap-4">
+                {(yesFirst ? [true, false] : [false, true]).map(val => (
+                  <label key={String(val)} className="flex items-center gap-1.5 text-sm cursor-pointer">
+                    <input
+                      type="radio"
+                      checked={defaults[key] === val}
+                      onChange={() => setDefaults({ ...defaults, [key]: val })}
+                      className="accent-[#1a2e5e]"
+                    />
+                    <span className="text-gray-700 dark:text-gray-300">{val ? "Yes" : "No"}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={handleSaveDefaults}
+          disabled={savingDefaults}
+          className="mt-2 px-5 py-2 text-sm font-semibold text-white bg-[#1a2e5e] hover:opacity-90 rounded-lg disabled:opacity-50 transition-opacity"
+        >
+          {savingDefaults ? "Saving…" : "Save defaults"}
+        </button>
       </div>
 
       {/* Notifications */}

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -241,23 +241,10 @@ async function fillCurrentStep(scope, application) {
     if (input.value) continue
     const label = getInputLabel(input)
     if (!label) continue
-
-    const l = label.toLowerCase()
-    console.log('JobAgent: filling input:', l)
-
-    if (l.includes('linkedin') || l.includes('profile')) {
-      setInputValue(input, application.linkedin_url ||
-        `https://www.linkedin.com/in/${application.user_name || 'profile'}`)
-    } else if (l.includes('phone') || l.includes('mobile')) {
-      setInputValue(input, application.phone || '')
-    } else if (l.includes('website') || l.includes('portfolio')) {
-      setInputValue(input, application.portfolio || '')
-    } else if (l.includes('city') || l.includes('location')) {
-      setInputValue(input, application.city || 'Tel Aviv')
-    } else if (l.includes('salary') || l.includes('compensation')) {
-      setInputValue(input, application.expected_salary || '')
-    } else if (l.includes('notice') || l.includes('start date')) {
-      setInputValue(input, application.notice_period || '30 days')
+    const answer = getAnswerForLabel(label, application)
+    if (answer) {
+      console.log('JobAgent: filling input:', label, '→', answer.substring(0, 30))
+      setInputValue(input, answer)
     }
   }
 
@@ -266,30 +253,32 @@ async function fillCurrentStep(scope, application) {
   for (const input of numberInputs) {
     if (input.value) continue
     const label = getInputLabel(input)
-    setInputValue(input, getYearsAnswer(label, application.skills || []))
+    const answer = getAnswerForLabel(label, application) || getYearsAnswer(label, application.skills || [])
+    setInputValue(input, answer)
   }
 
   // Fieldsets with real radio inputs (work auth, sponsorship, yes/no questions)
   const fieldsets = scope.querySelectorAll('fieldset')
   for (const fieldset of fieldsets) {
-    const legend = fieldset.querySelector('legend, span')
-    console.log('JobAgent: fieldset legend:', legend?.textContent?.substring(0, 50))
+    const legend = fieldset.querySelector('legend')
+    const legendText = legend?.textContent?.trim() || ''
+    console.log('JobAgent: fieldset legend:', legendText.substring(0, 50))
 
     const radios = fieldset.querySelectorAll('input[type="radio"]')
     const alreadySelected = Array.from(radios).find(r => r.checked)
     if (alreadySelected || radios.length === 0) continue
 
-    // Prefer "Yes" for auth/sponsorship questions; fall back to first option
-    const yesRadio = Array.from(radios).find(r =>
-      r.value?.toLowerCase() === 'yes' ||
-      r.nextSibling?.textContent?.toLowerCase().includes('yes') ||
-      r.parentElement?.textContent?.toLowerCase().includes('yes')
-    )
-    const toClick = yesRadio || radios[0]
-    console.log('JobAgent: clicking radio:', toClick?.value,
-      toClick?.parentElement?.textContent?.trim().substring(0, 30))
-    toClick.click()
-    toClick.dispatchEvent(new Event('change', { bubbles: true }))
+    // Decide yes/no based on user's profile defaults
+    const wantYes = getBooleanAnswer(legendText, application)
+    const target = Array.from(radios).find(r => {
+      const val = (r.value || r.parentElement?.textContent || '').toLowerCase()
+      return wantYes ? val.includes('yes') : val.includes('no')
+    }) || (wantYes ? radios[0] : radios[radios.length - 1])
+
+    console.log('JobAgent: clicking radio:', target?.value,
+      target?.parentElement?.textContent?.trim().substring(0, 30))
+    target.click()
+    target.dispatchEvent(new Event('change', { bubbles: true }))
   }
 
   // ARIA radiogroups (older LinkedIn UI)
@@ -357,18 +346,53 @@ function getYearsAnswer(label, skills) {
   return hasSkill ? '2' : '0'
 }
 
-function getAnswerForField(label, application) {
+// Returns the right string answer for a text/number field given its label
+function getAnswerForLabel(label, application) {
   if (!label) return null
   const l = label.toLowerCase()
 
-  if (l.includes('phone') || l.includes('mobile')) return application.phone
+  // URLs
+  if (l.includes('linkedin') || l.includes('profile url')) return application.linkedin_url || ''
+  if (l.includes('github')) return application.github_url || ''
+  if (l.includes('portfolio') || l.includes('website')) return application.portfolio_url || ''
+
+  // Personal
+  if (l.includes('first name')) return application.first_name || ''
+  if (l.includes('last name') || l.includes('family name')) return application.last_name || ''
+  if (l.includes('phone') || l.includes('mobile')) return application.phone || ''
   if (l.includes('city') || l.includes('location')) return application.city || 'Tel Aviv'
-  if (l.includes('linkedin')) return application.linkedin_url || ''
-  if (l.includes('website') || l.includes('portfolio')) return application.portfolio || ''
-  if (l.includes('salary') || l.includes('compensation')) return application.expected_salary || ''
-  if (l.includes('notice') || l.includes('start date')) return application.notice_period || '30 days'
+
+  // Work details
+  if (l.includes('salary') || l.includes('compensation') || l.includes('wage'))
+    return application.expected_salary || ''
+  if (l.includes('notice') || l.includes('availability') || l.includes('start date'))
+    return application.notice_period || '30'
+  if (l.includes('years') && l.includes('experience'))
+    return application.years_of_experience || '2'
+  if (l.includes('education') || l.includes('degree') || l.includes('qualification'))
+    return application.highest_education || "Bachelor's Degree"
 
   return null
+}
+
+// Returns the right boolean for a yes/no radio group given its label
+function getBooleanAnswer(label, application) {
+  if (!label) return true
+  const l = label.toLowerCase()
+
+  if (l.includes('authorized') || l.includes('eligible') || l.includes('right to work'))
+    return application.work_authorized ?? true
+  if (l.includes('sponsorship') || l.includes('visa'))
+    return !(application.requires_sponsorship ?? false) // "require sponsorship?" → No means false
+  if (l.includes('relocat'))
+    return application.willing_to_relocate ?? false
+
+  return true // default Yes for unknown yes/no questions
+}
+
+// Keep old name as alias — used by select dropdowns
+function getAnswerForField(label, application) {
+  return getAnswerForLabel(label, application)
 }
 
 function getInputLabel(input) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,12 +14,28 @@ model User {
   id                    String   @id @default(uuid())
   email                 String   @unique
   name                  String?
+  first_name            String?
+  last_name             String?
+  phone                 String?
+  city                  String?
   linkedin_session_path String?
   google_access_token   String?
   google_refresh_token  String?
   google_connected      Boolean  @default(false)
   email_notifications   Boolean  @default(true)
   created_at            DateTime @default(now())
+
+  // Easy Apply default answers
+  notice_period        String?  @default("30")
+  work_authorized      Boolean? @default(true)
+  requires_sponsorship Boolean? @default(false)
+  expected_salary      String?
+  years_of_experience  String?  @default("2")
+  highest_education    String?  @default("Bachelor's Degree")
+  linkedin_url         String?
+  portfolio_url        String?
+  github_url           String?
+  willing_to_relocate  Boolean? @default(false)
 
   cvs             CV[]
   job_preferences JobPreference[]


### PR DESCRIPTION
Closes #81

## Summary
- **Prisma schema**: 14 new fields on `User` — personal (first/last name, phone, city), URLs (LinkedIn, GitHub, portfolio), work details (salary, notice period, years of experience, education), and boolean preferences (work auth, sponsorship, relocation)
- **Profile page**: new "Auto Apply Defaults" card with its own Save button; populated on mount from `GET /api/profile`, saved via new `PATCH /api/profile`
- **check-pending API**: returns all default fields in the `application` object so the extension has everything it needs without extra round-trips
- **Extension content.js**: `getAnswerForLabel()` covers first/last name, all URLs, salary, notice period, years, education; `getBooleanAnswer()` picks Yes/No for radio groups based on the user's actual `work_authorized`, `requires_sponsorship`, `willing_to_relocate` values

## Test plan
- [ ] Fill in Auto Apply Defaults on Profile page → Save defaults → reload page → values persist
- [ ] Run Auto Apply on a LinkedIn job → check DevTools for "JobAgent: filling input: linkedin → https://..." etc.
- [ ] Verify radio buttons pick the correct Yes/No for work authorization and sponsorship questions
- [ ] `npx tsc --noEmit` passes (confirmed clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)