### PR TITLE
Add Easy Apply answer system: defaults + learn-as-you-go popup

### DIFF
--- a/app/api/apply/answers/route.ts
+++ b/app/api/apply/answers/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase.server";
+import { db } from "@/lib/db";
+
+async function getUser() {
+  const supabase = createServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  return user;
+}
+
+export async function GET(_req: NextRequest) {
+  try {
+    const user = await getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const answers = await db.easyApplyAnswer.findMany({
+      where: { user_id: user.id },
+      orderBy: { updated_at: "desc" },
+    });
+
+    return NextResponse.json({ answers });
+  } catch (err) {
+    console.error("[apply/answers GET]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    // Allow extension to pass userId directly (cross-site cookie blocked)
+    const supabase = createServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    const body = await req.json();
+    const userId = user?.id ?? body.userId;
+
+    if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { question, answer } = body;
+    if (!question || answer == null) {
+      return NextResponse.json({ error: "question and answer required" }, { status: 400 });
+    }
+
+    await db.easyApplyAnswer.upsert({
+      where: { user_id_question: { user_id: userId, question } },
+      create: { user_id: userId, question, answer },
+      update: { answer },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[apply/answers POST]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const user = await getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { question } = await req.json();
+    if (!question) return NextResponse.json({ error: "question required" }, { status: 400 });
+
+    await db.easyApplyAnswer.deleteMany({
+      where: { user_id: user.id, question },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[apply/answers DELETE]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/apply/check-pending/route.ts
+++ b/app/api/apply/check-pending/route.ts
@@ -76,8 +76,8 @@ export async function GET(request: NextRequest) {
 
   if (!rows.length) return NextResponse.json({ pending: false });
 
-  // Fetch profile defaults and CV skills in parallel
-  const [profile, cvRows] = await Promise.all([
+  // Fetch profile defaults, saved answers, and CV skills in parallel
+  const [profile, savedAnswers, cvRows] = await Promise.all([
     db.user.findUnique({
       where: { id: userId },
       select: {
@@ -97,6 +97,7 @@ export async function GET(request: NextRequest) {
         willing_to_relocate: true,
       },
     }),
+    db.easyApplyAnswer.findMany({ where: { user_id: userId } }),
     db.$queryRaw<{ skills_json: unknown }[]>`
       SELECT skills_json FROM "CV" WHERE user_id = ${userId} LIMIT 1
     `,
@@ -107,6 +108,10 @@ export async function GET(request: NextRequest) {
     if (Array.isArray(raw)) return raw as string[];
     return [];
   })();
+
+  const answersMap = Object.fromEntries(
+    savedAnswers.map((a) => [a.question, a.answer])
+  );
 
   return NextResponse.json({
     pending: true,
@@ -133,6 +138,8 @@ export async function GET(request: NextRequest) {
       willing_to_relocate: profile?.willing_to_relocate ?? false,
       // CV skills
       skills,
+      // Learned answers from previous applications
+      savedAnswers: answersMap,
     },
   });
 }

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -26,6 +26,13 @@ interface EasyApplyDefaults {
   willing_to_relocate: boolean;
 }
 
+interface SavedAnswer {
+  id: string;
+  question: string;
+  answer: string;
+  updated_at: string;
+}
+
 function ProfileContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -61,6 +68,10 @@ function ProfileContent() {
     work_authorized: true, requires_sponsorship: false, willing_to_relocate: false,
   });
   const [savingDefaults, setSavingDefaults] = useState(false);
+
+  // Saved answers (learned from previous Easy Apply sessions)
+  const [savedAnswers, setSavedAnswers] = useState<SavedAnswer[]>([]);
+  const [editingAnswer, setEditingAnswer] = useState<{ id: string; value: string } | null>(null);
 
   // Notifications
   const [emailNotifications, setEmailNotifications] = useState(true);
@@ -121,6 +132,12 @@ function ProfileContent() {
       })
       .catch(() => {})
       .finally(() => setLoading(false));
+
+    // Load saved Easy Apply answers
+    fetch("/api/apply/answers")
+      .then((r) => r.json())
+      .then((d) => { if (d.answers) setSavedAnswers(d.answers); })
+      .catch(() => {});
 
     // Check LinkedIn session status on mount — real Playwright validation (5-10 s)
     fetch("/api/linkedin/session-status")
@@ -185,6 +202,37 @@ function ProfileContent() {
       setLinkedinError(err instanceof Error ? err.message : "Something went wrong. Try again.");
     } finally {
       setLinkedinConnecting(false);
+    }
+  }
+
+  async function handleDeleteAnswer(question: string) {
+    try {
+      await fetch("/api/apply/answers", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question }),
+      });
+      setSavedAnswers((prev) => prev.filter((a) => a.question !== question));
+      showToast("Answer deleted", "success");
+    } catch {
+      showToast("Failed to delete answer", "error");
+    }
+  }
+
+  async function handleSaveEditedAnswer(question: string, answer: string) {
+    try {
+      await fetch("/api/apply/answers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question, answer }),
+      });
+      setSavedAnswers((prev) =>
+        prev.map((a) => a.question === question ? { ...a, answer } : a)
+      );
+      setEditingAnswer(null);
+      showToast("Answer saved", "success");
+    } catch {
+      showToast("Failed to save answer", "error");
     }
   }
 
@@ -857,6 +905,67 @@ function ProfileContent() {
         >
           {savingDefaults ? "Saving…" : "Save defaults"}
         </button>
+      </div>
+
+      {/* Saved Answers */}
+      <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl p-5">
+        <div className="mb-4">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Saved Answers</h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            Answers learned during previous Easy Apply sessions — reused automatically
+          </p>
+        </div>
+
+        {savedAnswers.length === 0 ? (
+          <p className="text-sm text-gray-400 dark:text-gray-500 italic">
+            No saved answers yet. They appear here after Easy Apply fills a form and you answer an unknown question.
+          </p>
+        ) : (
+          <div className="divide-y dark:divide-gray-700">
+            {savedAnswers.map((a) => (
+              <div key={a.id} className="py-3 flex items-start gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 font-medium mb-0.5 truncate">{a.question}</p>
+                  {editingAnswer?.id === a.id ? (
+                    <div className="flex gap-2 mt-1">
+                      <input
+                        type="text"
+                        value={editingAnswer.value}
+                        onChange={(e) => setEditingAnswer({ ...editingAnswer, value: e.target.value })}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") handleSaveEditedAnswer(a.question, editingAnswer.value);
+                          if (e.key === "Escape") setEditingAnswer(null);
+                        }}
+                        className="flex-1 border dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-1 focus:ring-[#1a2e5e]"
+                        autoFocus
+                      />
+                      <button
+                        onClick={() => handleSaveEditedAnswer(a.question, editingAnswer.value)}
+                        className="text-xs text-white bg-[#1a2e5e] px-2 py-1 rounded"
+                      >Save</button>
+                      <button
+                        onClick={() => setEditingAnswer(null)}
+                        className="text-xs text-gray-500 px-2 py-1"
+                      >Cancel</button>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-900 dark:text-gray-100">{a.answer}</p>
+                  )}
+                </div>
+                <div className="flex gap-2 shrink-0 mt-0.5">
+                  <button
+                    onClick={() => setEditingAnswer({ id: a.id, value: a.answer })}
+                    className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                  >Edit</button>
+                  <button
+                    onClick={() => handleDeleteAnswer(a.question)}
+                    className="text-xs text-red-500 dark:text-red-400 hover:underline"
+                  >Delete</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Notifications */}

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -83,6 +83,29 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true
   }
 
+  if (message.type === 'SAVE_ANSWER') {
+    ;(async () => {
+      try {
+        const stored = await chrome.storage.local.get(['userId'])
+        const serverUrl = await getServerUrl()
+        await fetch(`${serverUrl}/api/apply/answers`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            userId: stored.userId,
+            question: message.question,
+            answer: message.answer,
+          }),
+        })
+        console.log('[JobAgent bg] saved answer for:', message.question)
+      } catch (e) {
+        console.error('[JobAgent bg] Failed to save answer:', e)
+      }
+      sendResponse({ success: true })
+    })()
+    return true
+  }
+
   // Content script cannot make cross-origin fetches on LinkedIn (CSP) so it
   // delegates the status update here. We use userId from storage instead of
   // credentials:include because SameSite=Lax blocks cookies in SW context.

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -245,7 +245,9 @@ async function fillCurrentStep(scope, application) {
 
     let answer = getAnswerForLabel(label, application)
 
-    if (!answer && label) {
+    // Only ask user for fields we don't recognise (null).
+    // Empty string means we recognised the field but have no data — skip silently.
+    if (answer === null && label) {
       answer = await getAnswerForUnknown(label, application)
     }
 

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -235,13 +235,20 @@ async function fillCurrentStep(scope, application) {
       .map(f => f.querySelector('legend')?.textContent?.trim())
   )
 
-  // Text / URL / textarea inputs
-  const textInputs = scope.querySelectorAll('input[type="text"], input[type="url"], textarea')
+  // Text / URL / email / textarea inputs
+  const textInputs = scope.querySelectorAll(
+    'input[type="text"], input[type="url"], input[type="email"], textarea'
+  )
   for (const input of textInputs) {
-    if (input.value) continue
+    if (input.value?.trim()) continue
     const label = getInputLabel(input)
-    if (!label) continue
-    const answer = getAnswerForLabel(label, application)
+
+    let answer = getAnswerForLabel(label, application)
+
+    if (!answer && label) {
+      answer = await getAnswerForUnknown(label, application)
+    }
+
     if (answer) {
       console.log('JobAgent: filling input:', label, '→', answer.substring(0, 30))
       setInputValue(input, answer)
@@ -251,34 +258,41 @@ async function fillCurrentStep(scope, application) {
   // Number inputs (years of experience)
   const numberInputs = scope.querySelectorAll('input[type="number"]')
   for (const input of numberInputs) {
-    if (input.value) continue
+    if (input.value?.trim()) continue
     const label = getInputLabel(input)
-    const answer = getAnswerForLabel(label, application) || getYearsAnswer(label, application.skills || [])
+    const answer = getAnswerForLabel(label, application)
+      || getYearsAnswer(label, application.skills || [])
+      || application.years_of_experience
+      || '2'
     setInputValue(input, answer)
   }
 
   // Fieldsets with real radio inputs (work auth, sponsorship, yes/no questions)
   const fieldsets = scope.querySelectorAll('fieldset')
   for (const fieldset of fieldsets) {
-    const legend = fieldset.querySelector('legend')
+    const legend = fieldset.querySelector('legend, [data-test-form-element-label]')
     const legendText = legend?.textContent?.trim() || ''
     console.log('JobAgent: fieldset legend:', legendText.substring(0, 50))
 
     const radios = fieldset.querySelectorAll('input[type="radio"]')
-    const alreadySelected = Array.from(radios).find(r => r.checked)
+    const alreadySelected = Array.from(radios).some(r => r.checked)
     if (alreadySelected || radios.length === 0) continue
 
-    // Decide yes/no based on user's profile defaults
     const wantYes = getBooleanAnswer(legendText, application)
     const target = Array.from(radios).find(r => {
-      const val = (r.value || r.parentElement?.textContent || '').toLowerCase()
-      return wantYes ? val.includes('yes') : val.includes('no')
+      const lbl = r.closest('label') || fieldset.querySelector(`label[for="${r.id}"]`)
+      const text = (lbl?.textContent || r.value || '').toLowerCase()
+      return wantYes
+        ? text.includes('yes') || text.includes('כן')
+        : text.includes('no') || text.includes('לא')
     }) || (wantYes ? radios[0] : radios[radios.length - 1])
 
-    console.log('JobAgent: clicking radio:', target?.value,
-      target?.parentElement?.textContent?.trim().substring(0, 30))
-    target.click()
-    target.dispatchEvent(new Event('change', { bubbles: true }))
+    if (target) {
+      console.log('JobAgent: clicking radio:', target.value,
+        'for question:', legendText.substring(0, 50))
+      target.click()
+      target.dispatchEvent(new Event('change', { bubbles: true }))
+    }
   }
 
   // ARIA radiogroups (older LinkedIn UI)
@@ -298,15 +312,20 @@ async function fillCurrentStep(scope, application) {
     const label = getInputLabel(select)
     console.log('JobAgent: select field:', label)
 
-    const answer = getAnswerForField(label, application)
+    const answer = getAnswerForLabel(label, application)
     if (answer) {
-      select.value = answer
-      select.dispatchEvent(new Event('change', { bubbles: true }))
+      const match = Array.from(select.options).find(o =>
+        o.text.toLowerCase().includes(answer.toLowerCase()) ||
+        o.value.toLowerCase().includes(answer.toLowerCase())
+      )
+      if (match) {
+        select.value = match.value
+        select.dispatchEvent(new Event('change', { bubbles: true }))
+      }
     } else {
-      // Fall back to first non-empty option
-      const firstOption = Array.from(select.options).find(o => o.value && o.value !== '')
-      if (firstOption) {
-        select.value = firstOption.value
+      const first = Array.from(select.options).find(o => o.value && o.value !== '')
+      if (first) {
+        select.value = first.value
         select.dispatchEvent(new Event('change', { bubbles: true }))
       }
     }
@@ -346,31 +365,77 @@ function getYearsAnswer(label, skills) {
   return hasSkill ? '2' : '0'
 }
 
-// Returns the right string answer for a text/number field given its label
+// Returns the right string answer for a text/number/url/email field given its label
 function getAnswerForLabel(label, application) {
   if (!label) return null
-  const l = label.toLowerCase()
+  const l = label.toLowerCase().trim()
 
-  // URLs
-  if (l.includes('linkedin') || l.includes('profile url')) return application.linkedin_url || ''
+  // ── Personal ──────────────────────────────────
+  if (l.includes('first name') || l === 'name') return application.first_name || ''
+  if (l.includes('last name') || l.includes('family name') || l.includes('surname'))
+    return application.last_name || ''
+  if (l.includes('full name'))
+    return `${application.first_name || ''} ${application.last_name || ''}`.trim()
+  if (l.includes('phone') || l.includes('mobile') || l.includes('telephone'))
+    return application.phone || ''
+  if (l.includes('email')) return application.email || ''
+  if (l.includes('city') || l.includes('location') || l.includes('address'))
+    return application.city || 'Tel Aviv'
+  if (l.includes('country')) return 'Israel'
+  if (l.includes('zip') || l.includes('postal')) return ''
+
+  // ── URLs ──────────────────────────────────────
+  if (l.includes('linkedin')) return application.linkedin_url || ''
   if (l.includes('github')) return application.github_url || ''
-  if (l.includes('portfolio') || l.includes('website')) return application.portfolio_url || ''
+  if (l.includes('portfolio') || l.includes('website') || l.includes('personal site'))
+    return application.portfolio_url || ''
 
-  // Personal
-  if (l.includes('first name')) return application.first_name || ''
-  if (l.includes('last name') || l.includes('family name')) return application.last_name || ''
-  if (l.includes('phone') || l.includes('mobile')) return application.phone || ''
-  if (l.includes('city') || l.includes('location')) return application.city || 'Tel Aviv'
-
-  // Work details
-  if (l.includes('salary') || l.includes('compensation') || l.includes('wage'))
+  // ── Salary ────────────────────────────────────
+  if (
+    l.includes('salary') || l.includes('compensation') || l.includes('wage') ||
+    l.includes('pay') || l.includes('ctc') || l.includes('package') ||
+    l.includes('expected') || l.includes('desired') ||
+    l.includes('שכר') || l.includes('פיצוי') || l.includes('שכר מצופה')
+  )
     return application.expected_salary || ''
-  if (l.includes('notice') || l.includes('availability') || l.includes('start date'))
+
+  // ── Work Timeline ─────────────────────────────
+  if (
+    l.includes('notice') || l.includes('start date') || l.includes('availability') ||
+    l.includes('when can you start') || l.includes('joining') ||
+    l.includes('available from') || l.includes('זמינות') || l.includes('התחלה')
+  )
     return application.notice_period || '30'
-  if (l.includes('years') && l.includes('experience'))
+
+  // ── Experience ────────────────────────────────
+  if (
+    (l.includes('year') && l.includes('experience')) ||
+    (l.includes('how many year') && l.includes('work')) ||
+    l.includes('total experience') || l.includes('years of work') ||
+    l.includes('שנות ניסיון')
+  )
     return application.years_of_experience || '2'
-  if (l.includes('education') || l.includes('degree') || l.includes('qualification'))
+
+  // ── Education ─────────────────────────────────
+  if (
+    l.includes('education') || l.includes('degree') || l.includes('qualification') ||
+    l.includes('highest level') || l.includes('academic') || l.includes('השכלה')
+  )
     return application.highest_education || "Bachelor's Degree"
+
+  // ── Cover Letter / Summary ────────────────────
+  if (
+    l.includes('cover letter') || l.includes('why do you want') ||
+    l.includes('tell us about yourself') || l.includes('introduce yourself') ||
+    l.includes('מכתב מוטיבציה')
+  )
+    return application.cover_letter || ''
+
+  // ── Languages ─────────────────────────────────
+  if (l.includes('english') && (l.includes('level') || l.includes('proficiency')))
+    return 'Full Professional Proficiency'
+  if (l.includes('hebrew') && (l.includes('level') || l.includes('proficiency')))
+    return 'Native or Bilingual'
 
   return null
 }
@@ -380,19 +445,128 @@ function getBooleanAnswer(label, application) {
   if (!label) return true
   const l = label.toLowerCase()
 
-  if (l.includes('authorized') || l.includes('eligible') || l.includes('right to work'))
+  if (
+    l.includes('authorized') || l.includes('authorization') ||
+    l.includes('eligible to work') || l.includes('right to work') ||
+    l.includes('legally') || l.includes('work permit') ||
+    l.includes('מורשה') || l.includes('רשאי')
+  )
     return application.work_authorized ?? true
-  if (l.includes('sponsorship') || l.includes('visa'))
-    return !(application.requires_sponsorship ?? false) // "require sponsorship?" → No means false
-  if (l.includes('relocat'))
+
+  // "Do you require sponsorship?" — Yes means they need it
+  if (
+    l.includes('sponsor') || l.includes('visa') || l.includes('work visa') ||
+    l.includes('ויזה') || l.includes('חסות')
+  )
+    return application.requires_sponsorship ?? false
+
+  if (
+    l.includes('relocat') || l.includes('willing to move') ||
+    l.includes('open to relocation') || l.includes('מעבר דירה')
+  )
     return application.willing_to_relocate ?? false
 
-  return true // default Yes for unknown yes/no questions
+  if (l.includes('remote') && l.includes('work')) return true
+  if (l.includes('hybrid')) return true
+
+  return true
 }
 
-// Keep old name as alias — used by select dropdowns
+// Keep old name as alias
 function getAnswerForField(label, application) {
   return getAnswerForLabel(label, application)
+}
+
+// ── Learn-as-you-go popup ─────────────────────────────────────────────────────
+
+function showQuestionOverlay(question, onAnswer) {
+  document.getElementById('jobagent-question-overlay')?.remove()
+
+  const overlay = document.createElement('div')
+  overlay.id = 'jobagent-question-overlay'
+  overlay.style.cssText = `
+    position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);
+    z-index:999999;background:white;border:2px solid #1a2e5e;
+    border-radius:12px;padding:24px;min-width:400px;max-width:500px;
+    box-shadow:0 20px 60px rgba(0,0,0,0.3);
+    font-family:-apple-system,BlinkMacSystemFont,sans-serif;
+  `
+  overlay.innerHTML = `
+    <div style="display:flex;align-items:center;gap:8px;margin-bottom:16px">
+      <div style="background:#1a2e5e;color:white;padding:4px 12px;
+                  border-radius:20px;font-size:12px;font-weight:600">JobAgent</div>
+      <span style="font-size:13px;color:#666">needs your help</span>
+    </div>
+    <p style="font-size:15px;font-weight:500;color:#111;margin-bottom:16px;line-height:1.5">
+      ${question}
+    </p>
+    <input id="jobagent-answer-input" type="text" placeholder="Type your answer…"
+      style="width:100%;padding:10px 12px;border:2px solid #1a2e5e;border-radius:8px;
+             font-size:14px;box-sizing:border-box;margin-bottom:10px;outline:none;" />
+    <label style="display:flex;align-items:center;gap:8px;font-size:13px;
+                  color:#666;margin-bottom:16px;cursor:pointer">
+      <input type="checkbox" id="jobagent-save-answer" checked
+             style="width:16px;height:16px;cursor:pointer" />
+      Remember this answer for future applications
+    </label>
+    <div style="display:flex;gap:8px">
+      <button id="jobagent-submit-answer" style="flex:1;background:#1a2e5e;color:white;
+        border:none;padding:11px;border-radius:8px;font-size:14px;
+        font-weight:500;cursor:pointer;">Continue →</button>
+      <button id="jobagent-skip-answer" style="padding:11px 16px;background:#f5f6f8;
+        border:1px solid #e0e0e0;border-radius:8px;font-size:14px;
+        cursor:pointer;color:#666;">Skip</button>
+    </div>
+  `
+
+  document.body.appendChild(overlay)
+  const input = document.getElementById('jobagent-answer-input')
+  input.focus()
+
+  const submit = () => {
+    const answer = input.value.trim()
+    const save = document.getElementById('jobagent-save-answer').checked
+    overlay.remove()
+    onAnswer(answer || null, save)
+  }
+
+  document.getElementById('jobagent-submit-answer').onclick = submit
+  document.getElementById('jobagent-skip-answer').onclick = () => {
+    overlay.remove()
+    onAnswer(null, false)
+  }
+  input.addEventListener('keydown', e => { if (e.key === 'Enter') submit() })
+}
+
+async function getAnswerForUnknown(question, application) {
+  if (!question) return null
+  const normalized = question.toLowerCase().trim()
+
+  // Check saved answers from previous applications
+  if (application.savedAnswers?.[normalized]) {
+    console.log('JobAgent: using saved answer for:', normalized)
+    return application.savedAnswers[normalized]
+  }
+
+  // Ask user via popup
+  return new Promise((resolve) => {
+    showQuestionOverlay(question, async (answer, save) => {
+      if (answer && save) {
+        try {
+          await chrome.runtime.sendMessage({
+            type: 'SAVE_ANSWER',
+            question: normalized,
+            answer,
+          })
+          if (!application.savedAnswers) application.savedAnswers = {}
+          application.savedAnswers[normalized] = answer
+        } catch (e) {
+          console.error('JobAgent: failed to send SAVE_ANSWER', e)
+        }
+      }
+      resolve(answer)
+    })
+  })
 }
 
 function getInputLabel(input) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,11 +36,26 @@ model User {
   portfolio_url        String?
   github_url           String?
   willing_to_relocate  Boolean? @default(false)
+  cover_letter_default String?
 
-  cvs             CV[]
-  job_preferences JobPreference[]
-  applications    Application[]
-  interactions    UserJobInteraction[]
+  cvs              CV[]
+  job_preferences  JobPreference[]
+  applications     Application[]
+  interactions     UserJobInteraction[]
+  easy_apply_answers EasyApplyAnswer[]
+}
+
+model EasyApplyAnswer {
+  id         String   @id @default(uuid())
+  user_id    String
+  question   String
+  answer     String
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  user User @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([user_id, question])
 }
 
 model CV {


### PR DESCRIPTION
Closes #83

## Summary
- **EasyApplyAnswer model** — stores per-user question→answer pairs; unique on `(user_id, question)`
- **`/api/apply/answers`** — GET/POST/DELETE; POST accepts `userId` query param so the extension (which can't use cookies cross-site) can save answers
- **check-pending** — returns `savedAnswers` map alongside profile fields; extension uses it before showing any popup
- **Extension `content.js`** — comprehensive `getAnswerForLabel` (Hebrew keywords, languages, full name, cover letter); `getBooleanAnswer` with Hebrew; `showQuestionOverlay` popup for unknown fields with "remember" checkbox; `getAnswerForUnknown` checks saved map then shows popup; updated `fillCurrentStep` includes `type="email"` inputs and better select matching
- **`background.js`** — `SAVE_ANSWER` handler POSTs to server
- **Profile page** — "Saved Answers" card: lists all learned answers, inline edit (Enter/Esc), delete button

## Test plan
- [ ] Run Auto Apply on a job with an unknown field → popup appears → answer saved → recheck profile Saved Answers table
- [ ] Run Auto Apply again on same job → popup does not appear (uses saved answer)
- [ ] Edit / delete a saved answer from profile page → changes reflected next apply
- [ ] `npx tsc --noEmit` passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)