### PR TITLE
Add daily job cleanup: soft delete 30d, hard delete 90d

### DIFF
--- a/.github/workflows/daily-cleanup.yml
+++ b/.github/workflows/daily-cleanup.yml
@@ -1,0 +1,39 @@
+name: Daily Job Cleanup
+
+on:
+  schedule:
+    # Runs at 07:00 UTC daily — after APScheduler scrape (05:00) + match (06:00)
+    - cron: '0 7 * * *'
+  workflow_dispatch: # allow manual trigger from GitHub UI
+
+jobs:
+  cleanup:
+    name: Cleanup stale jobs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run job cleanup
+        run: |
+          echo "Running job cleanup at $(date -u)..."
+
+          RESULT=$(curl -s -X POST https://jobagent.uk/api/admin/cleanup-jobs \
+            -H "x-api-key: ${{ secrets.INTERNAL_API_KEY }}" \
+            -H "Content-Type: application/json")
+
+          echo "Cleanup result: $RESULT"
+
+          SUCCESS=$(echo "$RESULT" | python3 -c "
+          import json, sys
+          try:
+              d = json.load(sys.stdin)
+              print(d.get('success', False))
+          except Exception as e:
+              print(False)
+          ")
+
+          if [ "$SUCCESS" != "True" ]; then
+            echo "Cleanup failed or returned unexpected response!"
+            exit 1
+          fi
+
+          echo "Cleanup completed successfully"

--- a/app/api/admin/cleanup-jobs/route.ts
+++ b/app/api/admin/cleanup-jobs/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/db"
+
+// POST — run cleanup (soft delete 30d, hard delete 90d, deactivate broken URLs)
+// GET  — preview what would be cleaned without making changes
+// Both protected by INTERNAL_API_KEY header.
+//
+// Usage:
+//   curl -X POST https://jobagent.uk/api/admin/cleanup-jobs \
+//     -H "x-api-key: <INTERNAL_API_KEY>"
+
+export async function POST(req: NextRequest) {
+  const key = req.headers.get("x-api-key")
+  if (!key || key !== process.env.INTERNAL_API_KEY) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  try {
+    const now = new Date()
+    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
+    const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000)
+
+    // Step 1 — Soft delete: mark jobs older than 30 days as inactive.
+    // They stay in DB but are hidden from browse/match queries.
+    const softDeleted = await db.job.updateMany({
+      where: {
+        scraped_at: { lt: thirtyDaysAgo },
+        is_active: { not: false },
+      },
+      data: { is_active: false },
+    })
+    console.log(`[cleanup] soft deleted: ${softDeleted.count}`)
+
+    // Step 2 — Hard delete: remove jobs older than 90 days with no applications.
+    const hardDeleted = await db.$executeRaw`
+      DELETE FROM "Job"
+      WHERE scraped_at < ${ninetyDaysAgo}
+        AND id NOT IN (
+          SELECT DISTINCT job_id
+          FROM "Application"
+          WHERE job_id IS NOT NULL
+        )
+    `
+    console.log(`[cleanup] hard deleted: ${hardDeleted}`)
+
+    // Step 3 — Deactivate jobs with known broken URL patterns.
+    const brokenUrls = await db.job.updateMany({
+      where: {
+        is_active: { not: false },
+        OR: [
+          { url: { contains: "error=true" } },
+          { url: { contains: "?error" } },
+          { url: { contains: "job-closed" } },
+          { url: { contains: "position-filled" } },
+          { url: "" },
+        ],
+      },
+      data: { is_active: false },
+    })
+    console.log(`[cleanup] broken URLs deactivated: ${brokenUrls.count}`)
+
+    // Step 4 — Report current DB state.
+    const [activeCount, inactiveCount, totalCount] = await Promise.all([
+      db.job.count({ where: { is_active: true } }),
+      db.job.count({ where: { is_active: false } }),
+      db.job.count(),
+    ])
+
+    const result = {
+      success: true,
+      timestamp: now.toISOString(),
+      softDeleted: softDeleted.count,
+      hardDeleted: Number(hardDeleted),
+      brokenUrlsDeactivated: brokenUrls.count,
+      dbState: {
+        active: activeCount,
+        inactive: inactiveCount,
+        total: totalCount,
+      },
+    }
+
+    console.log("[cleanup] complete:", result)
+    return NextResponse.json(result)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error"
+    console.error("[cleanup] error:", message)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+// GET — preview what would be affected without making changes.
+export async function GET(req: NextRequest) {
+  const key = req.headers.get("x-api-key")
+  if (!key || key !== process.env.INTERNAL_API_KEY) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)
+
+  const [activeCount, inactiveCount, totalCount, olderThan30, olderThan90, brokenUrls] =
+    await Promise.all([
+      db.job.count({ where: { is_active: true } }),
+      db.job.count({ where: { is_active: false } }),
+      db.job.count(),
+      db.job.count({ where: { scraped_at: { lt: thirtyDaysAgo }, is_active: true } }),
+      db.job.count({ where: { scraped_at: { lt: ninetyDaysAgo } } }),
+      db.job.count({
+        where: {
+          OR: [
+            { url: { contains: "error=true" } },
+            { url: "" },
+          ],
+        },
+      }),
+    ])
+
+  return NextResponse.json({
+    dbState: {
+      active: activeCount,
+      inactive: inactiveCount,
+      total: totalCount,
+    },
+    wouldCleanup: {
+      softDelete: olderThan30,
+      eligibleForHardDelete: olderThan90,
+      brokenUrls,
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- `POST /api/admin/cleanup-jobs` — runs cleanup: marks jobs >30 days as `is_active=false`, hard deletes jobs >90 days with no applications, deactivates broken URL jobs
- `GET /api/admin/cleanup-jobs` — preview mode: shows what would be cleaned without making changes
- `.github/workflows/daily-cleanup.yml` — scheduled cron at 07:00 UTC daily (after APScheduler scrape @05:00 + match @06:00); also supports manual `workflow_dispatch` trigger

## Local test results

**GET preview before cleanup:**
```json
{"dbState":{"active":5936,"inactive":0,"total":5936},"wouldCleanup":{"softDelete":1677,"eligibleForHardDelete":0,"brokenUrls":0}}
```

**POST cleanup result:**
```json
{"success":true,"softDeleted":1677,"hardDeleted":0,"brokenUrlsDeactivated":0,"dbState":{"active":4259,"inactive":1677,"total":5936}}
```

1,677 stale jobs (>30 days) soft-deleted from 5,936 total. Active pool now 4,259.

## Test plan

- [x] TypeScript check passes (`npx tsc --noEmit`)
- [x] GET endpoint returns DB state preview
- [x] POST endpoint runs cleanup and returns counts
- [x] Unauthorized requests return 401
- [ ] GitHub Actions cron fires at 07:00 UTC tomorrow

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)