### PR TITLE
Add LinkedIn closed job detection to daily cleanup

### DIFF
--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI  # noqa: E402
 from routes.apply import router as apply_router  # noqa: E402
 from routes.cv import router as cv_router  # noqa: E402
 from routes.jobs import router as jobs_router  # noqa: E402
+from routes.jobs_cleanup import router as cleanup_router  # noqa: E402
 from routes.linkedin_auth import router as linkedin_auth_router  # noqa: E402
 from routes.matching import router as matching_router  # noqa: E402
 from scheduler import start_scheduler, stop_scheduler  # noqa: E402
@@ -28,6 +29,7 @@ app.include_router(jobs_router)
 app.include_router(matching_router)
 app.include_router(apply_router)
 app.include_router(linkedin_auth_router)
+app.include_router(cleanup_router)
 
 
 @app.get("/health")

--- a/ai-service/requirements.txt
+++ b/ai-service/requirements.txt
@@ -12,6 +12,7 @@ psycopg2-binary
 apscheduler
 python-multipart
 httpx
+aiohttp>=3.9.0
 beautifulsoup4
 reportlab
 pytest

--- a/ai-service/routes/jobs_cleanup.py
+++ b/ai-service/routes/jobs_cleanup.py
@@ -1,0 +1,138 @@
+import asyncio
+import os
+import sys
+import asyncpg
+import aiohttp
+from fastapi import APIRouter
+
+router = APIRouter()
+
+CLOSED_SIGNALS = [
+    "no longer accepting applications",
+    "not accepting applications",
+    "this job is closed",
+    "position has been filled",
+    "job has expired",
+    "application deadline has passed",
+]
+
+
+async def check_linkedin_job_closed(
+    session: aiohttp.ClientSession,
+    url: str,
+) -> bool:
+    """
+    Returns True if job is closed/no longer accepting.
+    Returns False if still open or if we can't tell.
+    """
+    try:
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            ),
+            "Accept-Language": "en-US,en;q=0.9",
+        }
+        async with session.get(
+            url,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=8),
+            allow_redirects=True,
+        ) as resp:
+            if resp.status == 404:
+                return True  # Job deleted
+            if resp.status != 200:
+                return False  # Can't tell — assume open
+
+            html = await resp.text()
+            html_lower = html.lower()
+
+            for signal in CLOSED_SIGNALS:
+                if signal in html_lower:
+                    return True
+
+            return False
+
+    except asyncio.TimeoutError:
+        return False  # Timeout — assume still open
+    except Exception as e:
+        print(f"[check_job] error checking {url}: {e}", file=sys.stderr)
+        return False  # Error — assume still open
+
+
+async def run_linkedin_closed_check(
+    batch_size: int = 50,
+    days_old: int = 7,
+) -> dict:
+    """
+    Check LinkedIn jobs that are N+ days old for closure.
+    Process in batches to avoid rate limiting.
+    """
+    database_url = os.getenv("DATABASE_URL", "")
+    if not database_url:
+        return {"error": "no DATABASE_URL"}
+
+    conn = await asyncpg.connect(database_url)
+
+    try:
+        jobs = await conn.fetch(f"""
+            SELECT id, url, title, company
+            FROM "Job"
+            WHERE is_active = true
+              AND url LIKE '%linkedin.com%'
+              AND scraped_at < NOW() - INTERVAL '{days_old} days'
+            ORDER BY scraped_at ASC
+            LIMIT {batch_size}
+        """)
+
+        print(f"[linkedin_check] checking {len(jobs)} jobs...")
+
+        deactivated = 0
+        checked = 0
+        semaphore = asyncio.Semaphore(3)
+
+        async def check_one(job):
+            nonlocal deactivated, checked
+            async with semaphore:
+                is_closed = await check_linkedin_job_closed(session, job["url"])
+                checked += 1
+                if is_closed:
+                    await conn.execute(
+                        'UPDATE "Job" SET is_active = false WHERE id = $1',
+                        job["id"],
+                    )
+                    deactivated += 1
+                    print(
+                        f"[linkedin_check] deactivated: "
+                        f"{job['title']} at {job['company']}"
+                    )
+                await asyncio.sleep(0.5)
+
+        connector = aiohttp.TCPConnector(limit=5)
+        async with aiohttp.ClientSession(connector=connector) as session:
+            tasks = [check_one(job) for job in jobs]
+            await asyncio.gather(*tasks)
+
+        result = {
+            "checked": checked,
+            "deactivated": deactivated,
+            "still_active": checked - deactivated,
+        }
+        print(f"[linkedin_check] complete: {result}")
+        return result
+
+    finally:
+        await conn.close()
+
+
+@router.post("/check-closed-jobs")
+async def check_closed_jobs_endpoint(
+    batch_size: int = 50,
+    days_old: int = 7,
+):
+    """Check LinkedIn jobs for closure. Call from admin API or scheduler."""
+    return await run_linkedin_closed_check(
+        batch_size=batch_size,
+        days_old=days_old,
+    )

--- a/app/api/admin/cleanup-jobs/route.ts
+++ b/app/api/admin/cleanup-jobs/route.ts
@@ -66,12 +66,33 @@ export async function POST(req: NextRequest) {
       db.job.count(),
     ])
 
+    // Step 5 — Check LinkedIn jobs for closure.
+    let linkedinCheck: Record<string, unknown> = {}
+    try {
+      const pythonUrl = process.env.PYTHON_SERVICE_URL || "http://fastapi:8000"
+      const checkRes = await fetch(
+        `${pythonUrl}/check-closed-jobs?batch_size=50&days_old=7`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+      if (checkRes.ok) {
+        linkedinCheck = await checkRes.json()
+        console.log("[cleanup] linkedin check:", linkedinCheck)
+      }
+    } catch (e) {
+      console.error("[cleanup] linkedin check failed:", e)
+      linkedinCheck = { error: "check failed" }
+    }
+
     const result = {
       success: true,
       timestamp: now.toISOString(),
       softDeleted: softDeleted.count,
       hardDeleted: Number(hardDeleted),
       brokenUrlsDeactivated: brokenUrls.count,
+      linkedinCheck,
       dbState: {
         active: activeCount,
         inactive: inactiveCount,


### PR DESCRIPTION
## Summary

- **`ai-service/routes/jobs_cleanup.py`** — new module that fetches each active LinkedIn job page and checks for 6 closed-state HTML signals (e.g. "no longer accepting applications", 404). Max 3 concurrent requests, 0.5 s delay between requests, 8 s timeout per job — conservatively safe for LinkedIn rate limits.
- **`ai-service/main.py`** — registers `cleanup_router` so `POST /check-closed-jobs` is live.
- **`ai-service/requirements.txt`** — adds `aiohttp>=3.9.0`.
- **`app/api/admin/cleanup-jobs/route.ts`** — adds Step 5 after the existing soft/hard delete steps: calls the Python service to check a batch of 50 LinkedIn jobs (7+ days old) and records the result in `linkedinCheck` in the response.

No GitHub Actions changes needed — `daily-cleanup.yml` already calls `/api/admin/cleanup-jobs` at 07:00 UTC daily (after the 05:00 scrape), so the LinkedIn check runs automatically.

## Behaviour

- Only deactivates a job when a **clear** closed signal is present — on timeout/error/non-200 it assumes the job is still open.
- Processes oldest jobs first so stale listings are cleaned up before newer ones.
- `linkedinCheck` is non-critical: a failure in Step 5 does not fail the rest of the cleanup response.

## Test plan

- [ ] Deploy and hit `POST /api/admin/cleanup-jobs` with the API key
- [ ] Confirm `linkedinCheck` appears in the JSON response with `checked`, `deactivated`, `still_active` fields
- [ ] Run a larger backfill batch: `curl -s -X POST "https://jobagent.uk/api/admin/cleanup-jobs" -H "x-api-key: KEY" | jq .`
- [ ] Verify deactivated jobs no longer appear in dashboard matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)